### PR TITLE
Table dict

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,9 +25,10 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Device (please complete the following information):**
- - OS: [e.g. iOS]
- - Python [e.g. version, installed packages]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Python [e.g. version, installed packages]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/security-vulnerability.md
+++ b/.github/ISSUE_TEMPLATE/security-vulnerability.md
@@ -13,6 +13,7 @@ A clear and concise description of what security concern you encountered and why
 **To Reproduce**
 *If it's a general security concern, leave this section empty*
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -20,13 +21,14 @@ Steps to reproduce the behavior:
 
 **Screenshots**
 *If it's a general security concern, leave this section empty*
-If applicable, add screenshots to help explain your problem. 
+If applicable, add screenshots to help explain your problem.
 
 **Device (please complete the following information):**
 *If it's a general security concern, leave this section empty*
- - OS: [e.g. iOS]
- - Python [e.g. version, installed packages]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Python [e.g. version, installed packages]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 permissions:
   contents: read
@@ -21,19 +21,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # others
 prototyping

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,38 @@
 # Contributing to ItsPrompt
 
-Thank you for your interest in contributing to ItsPrompt. We welcome and appreciate any contributions, whether it is code, documentation, bug reports, feature requests, or general feedback.
+Thank you for your interest in contributing to ItsPrompt. We welcome and appreciate any contributions, whether it is
+code, documentation, bug reports, feature requests, or general feedback.
 
 <!-- ## Code of Conduct
 
 By participating in this project, you agree to abide by the [Code of Conduct](https://github.com/TheItsProjects/ItsPrompt/blob/main/CODE_OF_CONDUCT.md). Please read it carefully and report any violations to the project maintainers.
  -->
+
 ## How to Contribute
 
 There are many ways you can contribute to this project. Here are some guidelines to help you get started.
 
 ### Reporting Issues
 
-If you encounter any problems or have any suggestions for improvement, please open an issue on GitHub using the appropriate template. Be as descriptive as possible and include any relevant information such as error messages, screenshots, or steps to reproduce the issue.
+If you encounter any problems or have any suggestions for improvement, please open an issue on GitHub using the
+appropriate template. Be as descriptive as possible and include any relevant information such as error messages,
+screenshots, or steps to reproduce the issue.
 
-*If you need help with creating an Issue, join our [Discord](https://discord.gg/rP9Qke2jDs) and don't hesitate to contact us!*
+*If you need help with creating an Issue, join our [Discord](https://discord.gg/rP9Qke2jDs) and don't hesitate to
+contact us!*
 
 ### Submitting Pull Requests
 
-If you want to contribute code or documentation to this project, you can submit a pull request (PR) on GitHub. Before you do so, please make sure that:
+If you want to contribute code or documentation to this project, you can submit a pull request (PR) on GitHub. Before
+you do so, please make sure that:
 
 - You have tested your code locally and ensured that it works as expected (also be sure you have added tests).
 - You have written clear and concise commit messages and PR descriptions.
 - You have updated the documentation if necessary.
 - You have resolved any merge conflicts with the main branch.
 
-*If you need help with opening a PR, join our [Discord](https://discord.gg/rP9Qke2jDs) and don't hesitate to contact us!*
+*If you need help with opening a PR, join our [Discord](https://discord.gg/rP9Qke2jDs) and don't hesitate to contact
+us!*
 
 To submit a PR, follow these steps:
 
@@ -41,9 +48,11 @@ To submit a PR, follow these steps:
 
 We value your feedback and opinions on this project. You can share them with us by:
 
-- Joining the [Discussions](https://github.com/TheItsProjects/ItsPrompt/discussions) section on GitHub and starting or joining a conversation.
+- Joining the [Discussions](https://github.com/TheItsProjects/ItsPrompt/discussions) section on GitHub and starting or
+  joining a conversation.
 - Joining our [Discord](https://discord.gg/rP9Qke2jDs) and letting us know what you think.
 
 ## Thank You
 
-We appreciate your time and effort in contributing to this project. We hope you enjoy using ItsPrompt and find it useful. Thank you for being part of our community!
+We appreciate your time and effort in contributing to this project. We hope you enjoy using ItsPrompt and find it
+useful. Thank you for being part of our community!

--- a/ItsPrompt/data/checkbox.py
+++ b/ItsPrompt/data/checkbox.py
@@ -8,9 +8,8 @@ class CheckboxOption:
     is_selected: bool
 
 
-def process_data(
-        options: tuple[str | tuple[str, str], ...]) -> list[CheckboxOption]:
-    '''
+def process_data(options: tuple[str | tuple[str, str], ...]) -> list[CheckboxOption]:
+    """
     Processes the given `options` and returns the processed list
 
     :param options: A list of options to process
@@ -18,25 +17,15 @@ def process_data(
     :raises TypeError: If an option is not processable, a `TypeError` will be raised
     :return: a list of `CheckboxOption`
     :rtype: list[CheckboxOption]
-    '''
+    """
     processed_options: list[CheckboxOption] = []
 
     # process given options
     for option in options:
         if type(option) is str:
-            processed_options.append(
-                CheckboxOption(
-                    name=option,
-                    id=option,
-                    is_selected=False,
-                ))
+            processed_options.append(CheckboxOption(name=option, id=option, is_selected=False))
         elif type(option) is tuple:
-            processed_options.append(
-                CheckboxOption(
-                    name=option[0],
-                    id=option[1],
-                    is_selected=False,
-                ))
+            processed_options.append(CheckboxOption(name=option[0], id=option[1], is_selected=False))
         else:
             raise TypeError('Argument is not processable')
 

--- a/ItsPrompt/data/expand.py
+++ b/ItsPrompt/data/expand.py
@@ -8,9 +8,8 @@ class ExpandOption:
     id: str
 
 
-def process_data(
-        options: tuple[str | tuple[str, str, str], ...]) -> list[ExpandOption]:
-    '''
+def process_data(options: tuple[str | tuple[str, str, str], ...]) -> list[ExpandOption]:
+    """
     Processes the given `options` and returns the processed list
 
     :param options: A list of options to process
@@ -22,7 +21,7 @@ def process_data(
     :raises TypeError: If an option is not processable
     :return: A list of `ExpandOptions`
     :rtype: list[ExpandOption]
-    '''
+    """
     # check if every key is unique, otherwise return error
     keys = [option[0] for option in options]
     if len(set(keys)) < len(keys):
@@ -46,28 +45,13 @@ def process_data(
     for option in options:
         if type(option) is str:
             # use first letter as key, and str as name and id
-            processed_options.append(
-                ExpandOption(
-                    key=option[0],
-                    name=option,
-                    id=option,
-                ))
+            processed_options.append(ExpandOption(key=option[0], name=option, id=option))
         elif type(option) is tuple:
-            processed_options.append(
-                ExpandOption(
-                    key=option[0],
-                    name=option[1],
-                    id=option[2],
-                ))
+            processed_options.append(ExpandOption(key=option[0], name=option[1], id=option[2]))
         else:
             raise TypeError('Argument is not processable')
 
     # append a help option
-    processed_options.append(
-        ExpandOption(
-            key='h',
-            name='Help Menu, list or hide all options',
-            id='',
-        ))
+    processed_options.append(ExpandOption(key='h', name='Help Menu, list or hide all options', id=''))
 
     return processed_options

--- a/ItsPrompt/data/select.py
+++ b/ItsPrompt/data/select.py
@@ -7,9 +7,8 @@ class SelectOption:
     id: str
 
 
-def process_data(
-        options: tuple[str | tuple[str, str], ...]) -> list[SelectOption]:
-    '''
+def process_data(options: tuple[str | tuple[str, str], ...]) -> list[SelectOption]:
+    """
     Processes the given `options` and returns the processed list
 
     :param options: A list of options to process
@@ -17,22 +16,15 @@ def process_data(
     :raises TypeError: If an option is not processable, a `TypeError` will be raised
     :return: a list of `SelectOptions`
     :rtype: list[SelectOption]
-    '''
+    """
     processed_options: list[SelectOption] = []
 
     # process given options
     for option in options:
         if type(option) is str:
-            processed_options.append(SelectOption(
-                name=option,
-                id=option,
-            ))
+            processed_options.append(SelectOption(name=option, id=option))
         elif type(option) is tuple:
-            processed_options.append(
-                SelectOption(
-                    name=option[0],
-                    id=option[1],
-                ))
+            processed_options.append(SelectOption(name=option[0], id=option[1]))
         else:
             raise TypeError('Argument is not processable')
 

--- a/ItsPrompt/data/table.py
+++ b/ItsPrompt/data/table.py
@@ -52,10 +52,10 @@ class Table:
         return self.data.get_column_location(col) == self.col_count - 1
 
     def _char_if_last_else_otherchar(
-            self,
-            col,
-            char: str,
-            otherchar: str,
+        self,
+        col,
+        char: str,
+        otherchar: str,
     ) -> str:
         """returns the `char` if the given column is the last in the DataFrame, otherwise returns the `otherchar`"""
         return char if self._col_is_last(col) else otherchar
@@ -68,8 +68,7 @@ class Table:
         """
 
         # set initial list (each entry represents a line to print)
-        table_out = [''] * (self.row_count * 2 + 1
-                            )  # 2 lines for every row + bottom border
+        table_out = [''] * (self.row_count * 2 + 1)  # 2 lines for every row + bottom border
 
         # append left border to every string
         table_out[0] += '┌'
@@ -82,9 +81,7 @@ class Table:
 
         # add headers
         for header in self.data.columns:
-            table_out[
-                0] += '─' * self.cell_width + self._char_if_last_else_otherchar(
-                header, '┐', '┬')
+            table_out[0] += '─' * self.cell_width + self._char_if_last_else_otherchar(header, '┐', '┬')
 
             if len(str(header)) > self.cell_width:
                 #   /\ convert the header to str in case the user did not give a header, so it is an integer
@@ -95,17 +92,11 @@ class Table:
         # add values, iterate over each column
         for header, values in self.data.items():
             # iterate over each row
-            for i, val in zip(
-                    range(2, len(table_out), 2),
-                    values):  # start at 2, because first two rows are header
-                table_out[
-                    i] += '─' * self.cell_width + self._char_if_last_else_otherchar(
-                    header, '┤', '┼')
+            for i, val in zip(range(2, len(table_out), 2), values):  # start at 2, because first two rows are header
+                table_out[i] += '─' * self.cell_width + self._char_if_last_else_otherchar(header, '┤', '┼')
                 table_out[i + 1] += f'{str(val):{self.cell_width}}' + '│'
 
-            table_out[
-                -1] += '─' * self.cell_width + self._char_if_last_else_otherchar(
-                header, '┘', '┴')
+            table_out[-1] += '─' * self.cell_width + self._char_if_last_else_otherchar(header, '┘', '┴')
 
         return '\n'.join(table_out)
 
@@ -122,12 +113,12 @@ class Table:
     def on_left(self):
         """when left is pressed, select same row, but column one to the left (or last column if current is 0)"""
 
-        self.cur_cell[0] = (self.cur_cell[0] - 1) % (self.col_count)
+        self.cur_cell[0] = (self.cur_cell[0] - 1) % self.col_count
 
     def on_right(self):
         """when right is pressed, select same row, but column one to the right (or first column if current is last)"""
 
-        self.cur_cell[0] = (self.cur_cell[0] + 1) % (self.col_count)
+        self.cur_cell[0] = (self.cur_cell[0] + 1) % self.col_count
 
     def add_key(self, key: str):
         """add key to current selected cell"""
@@ -141,11 +132,9 @@ class Table:
         """returns the current position of the cursor, relative to the top left corner character as (0, 0)"""
         y = self.cur_cell[1] * 2 + 3  # 3 is offset for header
 
-        item_length = len(
-            self.data.get_item_at(
-                self.cur_cell[1],
-                self.cur_cell[0]))  # length of the item in the current cell
+        item_length = len(self.data.get_item_at(self.cur_cell[1], self.cur_cell[0]))
+        # length of the item in the current cell
 
-        x = (self.cell_width + 1) * self.cur_cell[
-            0] + 1 + item_length  # 1 is offset for left border, item_length is length of item
-        return (x, y)
+        x = (self.cell_width + 1) * self.cur_cell[0] + 1 + item_length
+        # 1 is offset for left border, item_length is length of item
+        return x, y

--- a/ItsPrompt/data/table.py
+++ b/ItsPrompt/data/table.py
@@ -9,23 +9,23 @@ try:
     from pandas import DataFrame
 
     from ..objects.table.table_df import TableDataFromDF
-except ModuleNotFoundError:
-    # pandas is not installed
+except ModuleNotFoundError:  # pragma: no cover
+    # pandas were not installed
     pass
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pandas import DataFrame
 
 
 class Table:
 
     def __init__(self, data: Union["DataFrame", dict[str, list[str]]]) -> None:
-        '''
+        """
         Creates a table object for storing the drawable table instance
 
         :param data: the data to display
         :type data: DataFrame
-        '''
+        """
         # change type of all columns to str
         # TODO maybe later support more datatypes
         self.data: TableDataBase
@@ -48,24 +48,24 @@ class Table:
         self.cur_cell = [0, 0]  # ignoring header, as this can not be selected
 
     def _col_is_last(self, col) -> bool:
-        '''checks if the given column is the last column in the DataFrame'''
+        """checks if the given column is the last column in the DataFrame"""
         return self.data.get_column_location(col) == self.col_count - 1
 
     def _char_if_last_else_otherchar(
-        self,
-        col,
-        char: str,
-        otherchar: str,
+            self,
+            col,
+            char: str,
+            otherchar: str,
     ) -> str:
-        '''returns the `char` if the given column is the last in the DataFrame, otherwise returns the `otherchar`'''
+        """returns the `char` if the given column is the last in the DataFrame, otherwise returns the `otherchar`"""
         return char if self._col_is_last(col) else otherchar
 
     def get_table_as_str(self) -> str:
-        '''
+        """
         Returns the table as a printable string
-        
+
         Respects the width of the terminal at time of creation of the table object. Later this may be made dynamic.
-        '''
+        """
 
         # set initial list (each entry represents a line to print)
         table_out = [''] * (self.row_count * 2 + 1
@@ -84,7 +84,7 @@ class Table:
         for header in self.data.columns:
             table_out[
                 0] += '─' * self.cell_width + self._char_if_last_else_otherchar(
-                    header, '┐', '┬')
+                header, '┐', '┬')
 
             if len(str(header)) > self.cell_width:
                 #   /\ convert the header to str in case the user did not give a header, so it is an integer
@@ -100,45 +100,45 @@ class Table:
                     values):  # start at 2, because first two rows are header
                 table_out[
                     i] += '─' * self.cell_width + self._char_if_last_else_otherchar(
-                        header, '┤', '┼')
+                    header, '┤', '┼')
                 table_out[i + 1] += f'{str(val):{self.cell_width}}' + '│'
 
             table_out[
                 -1] += '─' * self.cell_width + self._char_if_last_else_otherchar(
-                    header, '┘', '┴')
+                header, '┘', '┴')
 
         return '\n'.join(table_out)
 
     def on_up(self):
-        '''when up is pressed, select same column, but row one above (or last row if current is 0)'''
+        """when up is pressed, select same column, but row one above (or last row if current is 0)"""
 
         self.cur_cell[1] = (self.cur_cell[1] - 1) % (self.row_count - 1)
 
     def on_down(self):
-        '''when down is pressed, select same column, but row one below (or first row if current is last)'''
+        """when down is pressed, select same column, but row one below (or first row if current is last)"""
 
         self.cur_cell[1] = (self.cur_cell[1] + 1) % (self.row_count - 1)
 
     def on_left(self):
-        '''when left is pressed, select same row, but column one to the left (or last column if current is 0)'''
+        """when left is pressed, select same row, but column one to the left (or last column if current is 0)"""
 
         self.cur_cell[0] = (self.cur_cell[0] - 1) % (self.col_count)
 
     def on_right(self):
-        '''when right is pressed, select same row, but column one to the right (or first column if current is last)'''
+        """when right is pressed, select same row, but column one to the right (or first column if current is last)"""
 
         self.cur_cell[0] = (self.cur_cell[0] + 1) % (self.col_count)
 
     def add_key(self, key: str):
-        '''add key to current selected cell'''
+        """add key to current selected cell"""
         self.data.add_key(self.cur_cell[1], self.cur_cell[0], key)
 
     def del_key(self):
-        '''remove last key from current selected cell'''
+        """remove last key from current selected cell"""
         self.data.del_key(self.cur_cell[1], self.cur_cell[0])
 
     def get_current_cursor_position(self) -> tuple[int, int]:
-        '''returns the current position of the cursor, relative to the top left corner character as (0, 0)'''
+        """returns the current position of the cursor, relative to the top left corner character as (0, 0)"""
         y = self.cur_cell[1] * 2 + 3  # 3 is offset for header
 
         item_length = len(

--- a/ItsPrompt/keyboard_handler.py
+++ b/ItsPrompt/keyboard_handler.py
@@ -3,42 +3,44 @@ from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
 
 
 def generate_key_bindings(app: type[Application]) -> KeyBindings:
-    '''
+    """
     Generates a KeyBindings object for use in a Prompt class
 
-    The `app` is used to check whether specific functions for handling the key events exist. It has to be a Prompt object (e.g. InputPrompt).
-    
+    The `app` is used to check whether specific functions for handling the key events exist. It has to be a Prompt
+    object (e.g. InputPrompt).
+
     The available functions are:
-    
+
     `on_up()`
-    
+
     `on_down()`
-    
+
     `on_left()`
-    
+
     `on_right()`
-    
+
     `on_enter()`
-    
+
     `on_space()`
-    
+
     `on_alt_enter()`
-    
+
     `on_backspace()`
-    
+
     `on_ctrl_backspace()`
-    
+
     `on_key()`
 
     :param app: An application type to check whether one of the above functions exists
     :type app: type[Application]
     :return: An usable KeyBindings instance
     :rtype: KeyBindings
-    '''
+    """
 
     kb = KeyBindings()
 
-    # Each of the options gets the keyboard input and runs the equivalent function in the event.app class, if the function exists.
+    # Each of the options gets the keyboard input and runs the equivalent function in the event.app class,
+    # if the function exists.
 
     @kb.add('c-c')
     def quit(event: KeyPressEvent):
@@ -87,7 +89,6 @@ def generate_key_bindings(app: type[Application]) -> KeyBindings:
     @kb.add('<any>', filter=hasattr(app, 'on_key'))
     def wildcard(event: KeyPressEvent):
         # wildcard function, used for prompts which need standard key presses like numbers or characters
-        event.app.on_key(  # type: ignore
-            [key.key for key in event.key_sequence], )
+        event.app.on_key([key.key for key in event.key_sequence])  # type: ignore
 
     return kb

--- a/ItsPrompt/objects/table/table_base.py
+++ b/ItsPrompt/objects/table/table_base.py
@@ -2,57 +2,57 @@ from abc import ABC, abstractmethod
 from typing import Generator
 
 
-class TableDataBase(ABC):
+class TableDataBase(ABC):  # pragma: no cover
 
     @property
     @abstractmethod
     def row_count(self) -> int:
-        '''Returns the number of rows in the table, including the header'''
+        """Returns the number of rows in the table, including the header"""
         pass
 
     @property
     @abstractmethod
     def col_count(self) -> int:
-        '''Returns the number of columns in the table'''
+        """Returns the number of columns in the table"""
         pass
 
     @property
     @abstractmethod
     def columns(self) -> tuple[str, ...]:
-        '''Returns the column names in the table (the first row, headers)'''
+        """Returns the column names in the table (the first row, headers)"""
         pass
 
     @abstractmethod
     def items(self) -> Generator[tuple[str, tuple[str, ...]], None, None]:
-        '''Gets all the items in the table (each tuple contains the header and the values)'''
+        """Gets all the items in the table (each tuple contains the header and the values)"""
         pass
 
     @abstractmethod
     def get_item_at(self, row: int, col: int) -> str:
-        '''Returns the item at the given position in the table'''
+        """Returns the item at the given position in the table"""
         pass
 
     @abstractmethod
     def set_item_at(self, row: int, col: int, val: str) -> None:
-        '''Sets the item at the given position in the table'''
+        """Sets the item at the given position in the table"""
         pass
 
     @abstractmethod
     def add_key(self, row: int, col: int, key: str):
-        '''Adds the key to the given cell'''
+        """Adds the key to the given cell"""
         pass
 
     @abstractmethod
     def del_key(self, row: int, col: int):
-        '''Deletes the key from the given cell'''
+        """Deletes the key from the given cell"""
         pass
 
     @abstractmethod
     def get_column_location(self, val: str) -> int:
-        '''Returns the location of the column in the table'''
+        """Returns the location of the column in the table"""
         pass
 
     @abstractmethod
     def get_data(self):
-        '''Returns the actual data'''
+        """Returns the actual data"""
         pass

--- a/ItsPrompt/objects/table/table_base.py
+++ b/ItsPrompt/objects/table/table_base.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+from typing import Generator
+
+
+class TableDataBase(ABC):
+
+    @property
+    @abstractmethod
+    def row_count(self) -> int:
+        '''Returns the number of rows in the table, including the header'''
+        pass
+
+    @property
+    @abstractmethod
+    def col_count(self) -> int:
+        '''Returns the number of columns in the table'''
+        pass
+
+    @property
+    @abstractmethod
+    def columns(self) -> tuple[str, ...]:
+        '''Returns the column names in the table (the first row, headers)'''
+        pass
+
+    @abstractmethod
+    def items(self) -> Generator[tuple[str, tuple[str, ...]], None, None]:
+        '''Gets all the items in the table (each tuple contains the header and the values)'''
+        pass
+
+    @abstractmethod
+    def get_item_at(self, row: int, col: int) -> str:
+        '''Returns the item at the given position in the table'''
+        pass
+
+    @abstractmethod
+    def set_item_at(self, row: int, col: int, val: str) -> None:
+        '''Sets the item at the given position in the table'''
+        pass
+
+    @abstractmethod
+    def add_key(self, row: int, col: int, key: str):
+        '''Adds the key to the given cell'''
+        pass
+
+    @abstractmethod
+    def del_key(self, row: int, col: int):
+        '''Deletes the key from the given cell'''
+        pass
+
+    @abstractmethod
+    def get_column_location(self, val: str) -> int:
+        '''Returns the location of the column in the table'''
+        pass
+
+    @abstractmethod
+    def get_data(self):
+        '''Returns the actual data'''
+        pass

--- a/ItsPrompt/objects/table/table_df.py
+++ b/ItsPrompt/objects/table/table_df.py
@@ -1,0 +1,49 @@
+from typing import Generator
+
+from pandas import DataFrame
+
+from .table_base import TableDataBase
+
+
+class TableDataFromDF(TableDataBase):
+
+    def __init__(self, data: DataFrame) -> None:
+        self.data = data.astype("str")  # convert all values to str
+        self.data = self.data.rename(
+            columns=lambda x: str(x))  # convert all headers to str
+
+    @property
+    def row_count(self) -> int:
+        return len(self.data) + 1
+
+    @property
+    def col_count(self) -> int:
+        return len(self.data.columns)
+
+    @property
+    def columns(self) -> tuple[str, ...]:
+        return tuple(self.data.columns)
+
+    def items(self) -> Generator[tuple[str, tuple[str, ...]], None, None]:
+        for header, values in self.data.items():
+            yield str(header), tuple(values)
+
+    def get_item_at(self, row: int, col: int) -> str:
+        return self.data.iat[row, col]
+
+    def set_item_at(self, row: int, col: int, val: str) -> None:
+        self.data.iat[row, col] = val
+
+    def add_key(self, row: int, col: int, key: str):
+        new = self.get_item_at(row, col) + key
+        self.set_item_at(row, col, new)
+
+    def del_key(self, row: int, col: int):
+        new = self.get_item_at(row, col)[:-1]
+        self.set_item_at(row, col, new)
+
+    def get_column_location(self, val: str) -> int:
+        return self.data.columns.get_loc(val)
+
+    def get_data(self) -> DataFrame:
+        return self.data

--- a/ItsPrompt/objects/table/table_df.py
+++ b/ItsPrompt/objects/table/table_df.py
@@ -9,8 +9,7 @@ class TableDataFromDF(TableDataBase):
 
     def __init__(self, data: DataFrame) -> None:
         self.data = data.astype("str")  # convert all values to str
-        self.data = self.data.rename(
-            columns=lambda x: str(x))  # convert all headers to str
+        self.data = self.data.rename(columns=lambda x: str(x))  # convert all headers to str
 
     @property
     def row_count(self) -> int:

--- a/ItsPrompt/objects/table/table_dict.py
+++ b/ItsPrompt/objects/table/table_dict.py
@@ -6,10 +6,10 @@ from .table_base import TableDataBase
 class TableDataFromDict(TableDataBase):
 
     def __init__(self, data: dict[str, list[str]]) -> None:
-        # make sure every tuple has same length
+        # make sure every list has same length
         lengths = set([len(t) for t in data.values()])
         if len(lengths) != 1:
-            raise ValueError("Dictionary values must be same length!")
+            raise ValueError("Dictionary columns (lists) must be same length!")
 
         self.data = data
 

--- a/ItsPrompt/objects/table/table_dict.py
+++ b/ItsPrompt/objects/table/table_dict.py
@@ -1,0 +1,56 @@
+from typing import Generator
+
+from .table_base import TableDataBase
+
+
+class TableDataFromDict(TableDataBase):
+
+    def __init__(self, data: dict[str, list[str]]) -> None:
+        # make sure every tuple has same length
+        lengths = set([len(t) for t in data.values()])
+        if len(lengths) != 1:
+            raise ValueError("Dictionary values must be same length!")
+
+        self.data = data
+
+    @property
+    def row_count(self) -> int:
+        return len(next(iter(self.data.values()))) + 1
+
+    @property
+    def col_count(self) -> int:
+        return len(self.data)
+
+    @property
+    def columns(self) -> tuple[str, ...]:
+        return tuple(self.data.keys())
+
+    def items(self) -> Generator[tuple[str, tuple[str, ...]], None, None]:
+        for header, values in self.data.items():
+            yield str(header), tuple(values)
+
+    def get_item_at(self, row: int, col: int) -> str:
+        # get the name of the column to edit (header)
+        col_name = self.columns[col]
+
+        return self.data[col_name][row]
+
+    def set_item_at(self, row: int, col: int, val: str) -> None:
+        # get the name of the column to edit (header)
+        col_name = self.columns[col]
+
+        self.data[col_name][row] = val
+
+    def add_key(self, row: int, col: int, key: str):
+        new = self.get_item_at(row, col) + key
+        self.set_item_at(row, col, new)
+
+    def del_key(self, row: int, col: int):
+        new = self.get_item_at(row, col)[:-1]
+        self.set_item_at(row, col, new)
+
+    def get_column_location(self, val: str) -> int:
+        return self.columns.index(val)
+
+    def get_data(self) -> dict[str, list[str]]:
+        return self.data

--- a/ItsPrompt/prompt.py
+++ b/ItsPrompt/prompt.py
@@ -1,25 +1,32 @@
-'''
+"""
 # ItsPrompt
 
 created by ItsNameless
 
 :copyright: (c) 2023-present ItsNameless
 :license: MIT, see LICENSE for more details.
-'''
+"""
 
 # mypy: disable-error-code=return-value
 
-from typing import TYPE_CHECKING, Callable, Union
+from typing import Callable, TYPE_CHECKING, Union
 
 from prompt_toolkit import HTML
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.completion import Completer
-from prompt_toolkit.layout.containers import (Float, FloatContainer, HSplit,
-                                              VSplit, Window)
+from prompt_toolkit.layout.containers import (
+    Float,
+    FloatContainer,
+    HSplit,
+    VSplit,
+    Window,
+)
 from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
 from prompt_toolkit.layout.layout import Layout
-from prompt_toolkit.layout.menus import (CompletionsMenu,
-                                         MultiColumnCompletionsMenu)
+from prompt_toolkit.layout.menus import (
+    CompletionsMenu,
+    MultiColumnCompletionsMenu,
+)
 
 from .data.style import PromptStyle, convert_style, default_style
 from .data.type import CompletionDict
@@ -37,16 +44,16 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class Prompt:
-    '''
+    """
     # Modern python prompter
-    
+
     This tool is used to ask the user questions, the fancy way.
-    
+
     Usage:
     ```
     answer = Prompt.checkbox('option 1', 'option 2')
     ```
-    '''
+    """
 
     @classmethod
     def select(
@@ -56,42 +63,48 @@ class Prompt:
         default: str | None = None,
         style: PromptStyle | None = None,
     ) -> str:
-        '''
+        """
         Ask the user for selecting ONE of the given `options`.
 
-        This method shows the question alongside the `options` as a nice list. The user has the ability to use the up, down and enter keys to navigate between the options and select the one thats right.
+        This method shows the question alongside the `options` as a nice list. The user has the ability to use the
+        up, down and enter keys to navigate between the options and select the one thats right.
 
-        The `options` are either a string, which is used as the display value and the id, or a tuple[str, str], where the first string is the display value and the second is the option's id.
+        The `options` are either a string, which is used as the display value and the id, or a tuple[str, str],
+        where the first string is the display value and the second is the option's id.
 
         :param question: The question to display
         :type question: str
         :param options: A list of possible options
         :type options: tuple[str  |  tuple[str, str], ...]
-        :param default: The id of the default option to select (empty or None if the first should be default), defaults to None
+        :param default: The id of the default option to select (empty or None if the first should be default),
+        defaults to None
         :type default: str | None, optional
         :param style: A separate style to style the prompt (empty or None for default style), defaults to None
         :type style: PromptStyle | None, optional
         :raises KeyboardInterrupt: When the user presses ctrl-c, `KeyboardInterrupt` will be raised
         :return: The id of the selected option
         :rtype: str
-        '''
+        """
         app = SelectPrompt(
             question,
             options,
             default,
             layout=Layout(
-                HSplit([
-                    Window(FormattedTextControl(), always_hide_cursor=True),
-                    Window(FormattedTextControl(
-                        HTML('Use UP, DOWN to select, ENTER to submit')),
-                           char=' ',
-                           style='class:tooltip',
-                           height=1)
-                ])),
+                HSplit(
+                    [
+                        Window(FormattedTextControl(), always_hide_cursor=True),
+                        Window(
+                            FormattedTextControl(HTML('Use UP, DOWN to select, ENTER to submit')),
+                            char=' ',
+                            style='class:tooltip',
+                            height=1
+                        )
+                    ]
+                )
+            ),
             key_bindings=generate_key_bindings(SelectPrompt),
             erase_when_done=True,
-            style=convert_style(style)
-            if style else convert_style(default_style),
+            style=convert_style(style) if style else convert_style(default_style),
         )
         ans = app.prompt()
         if ans == None:
@@ -107,18 +120,21 @@ class Prompt:
         allow_keyboard: bool = False,
         style: PromptStyle | None = None,
     ) -> str:
-        '''
+        """
         Ask the user for selection ONE of the given `options`.
 
-        This method shows the question alongside the `options` as a nice list. The user needs to type the index of the answer. If `allow_keyboard` is given, the user may use the keyboard as in the `select()` method.
+        This method shows the question alongside the `options` as a nice list. The user needs to type the index of
+        the answer. If `allow_keyboard` is given, the user may use the keyboard as in the `select()` method.
 
-        The `options` are either a string, which is used as the display value and the id, or a tuple[str, str], where the first string is the display value and the second is the option's id.
+        The `options` are either a string, which is used as the display value and the id, or a tuple[str, str],
+        where the first string is the display value and the second is the option's id.
 
         :param question: The question to display
         :type question: str
         :param options: A list of possible options
         :type options: tuple[str  |  tuple[str, str], ...]
-        :param default: The id of the default option to select (empty or None if the first should be default), defaults to None
+        :param default: The id of the default option to select (empty or None if the first should be default),
+        defaults to None
         :type default: str | None, optional
         :param allow_keyboard: Whether the user should be able to select the answer with up and down, defaults to False
         :type allow_keyboard: bool, optional
@@ -127,27 +143,28 @@ class Prompt:
         :raises KeyboardInterrupt: When the user presses ctrl-c, `KeyboardInterrupt` will be raised
         :return: The id of the selected option
         :rtype: str
-        '''
+        """
         app = RawSelectPrompt(
             question,
             options,
             default,
             allow_keyboard,
             layout=Layout(
-                HSplit([
-                    Window(FormattedTextControl(), always_hide_cursor=True),
-                    Window(FormattedTextControl(
-                        HTML(
-                            'Type the INDEX of your selection, ENTER to submit'
-                        )),
-                           char=' ',
-                           style='class:tooltip',
-                           height=1)
-                ])),
+                HSplit(
+                    [
+                        Window(FormattedTextControl(), always_hide_cursor=True),
+                        Window(
+                            FormattedTextControl(HTML('Type the INDEX of your selection, ENTER to submit')),
+                            char=' ',
+                            style='class:tooltip',
+                            height=1
+                        )
+                    ]
+                )
+            ),
             key_bindings=generate_key_bindings(RawSelectPrompt),
             erase_when_done=True,
-            style=convert_style(style)
-            if style else convert_style(default_style),
+            style=convert_style(style) if style else convert_style(default_style),
         )
         ans = app.prompt()
         if ans == None:
@@ -168,7 +185,8 @@ class Prompt:
 
         The user needs to type the key of the option. If the user types `h`, all options will be shown.
 
-        The `options` are either a string, where `s[0]` will be the key to select and the string will be used as name and id, or a tuple[str, str, str] where `t[0]` will be the key, `t[1]` the name and `t[2]` the id of the option.
+        The `options` are either a string, where `s[0]` will be the key to select and the string will be used as name
+        and id, or a tuple[str, str, str] where `t[0]` will be the key, `t[1]` the name and `t[2]` the id of the option.
 
         Every key must be a unique ascii character and of length 1, and there may not be a key assigned to `h`.
 
@@ -176,7 +194,8 @@ class Prompt:
         :type question: str
         :param options: A list of possible options
         :type options: tuple[str  |  tuple[str, str, str], ...]
-        :param default: The id of the default option to select (empty or None if `h` should be default), defaults to None
+        :param default: The id of the default option to select (empty or None if `h` should be default), defaults to
+        None
         :type default: str | None, optional
         :param allow_keyboard: Whether the user should be able to select the answer with up and down, defaults to False
         :type allow_keyboard: bool, optional
@@ -192,20 +211,23 @@ class Prompt:
             default,
             allow_keyboard,
             layout=Layout(
-                HSplit([
-                    Window(FormattedTextControl(), always_hide_cursor=True),
-                    Window(FormattedTextControl(
-                        HTML(
-                            'Type the KEY for your selection, ENTER to submit (use h to show all options)'
-                        )),
-                           char=' ',
-                           style='class:tooltip',
-                           height=1)
-                ])),
+                HSplit(
+                    [
+                        Window(FormattedTextControl(), always_hide_cursor=True),
+                        Window(
+                            FormattedTextControl(
+                                HTML('Type the KEY for your selection, ENTER to submit (use h to show all options)')
+                            ),
+                            char=' ',
+                            style='class:tooltip',
+                            height=1
+                        )
+                    ]
+                )
+            ),
             key_bindings=generate_key_bindings(ExpandPrompt),
             erase_when_done=True,
-            style=convert_style(style)
-            if style else convert_style(default_style),
+            style=convert_style(style) if style else convert_style(default_style),
         )
         ans = app.prompt()
         if ans == None:
@@ -217,8 +239,7 @@ class Prompt:
         cls,
         question: str,
         options: tuple[str | tuple[str, str], ...],
-        pointer_at: int
-        | None = None,
+        pointer_at: int | None = None,
         default_checked: tuple[str, ...] | None = None,
         min_selections: int = 0,
         style: PromptStyle | None = None,
@@ -226,9 +247,11 @@ class Prompt:
         """
         Ask the user for selecting MULTIPLE of the given `options`.
 
-        The `options` will be shown as a nice list. The user may navigate with up and down, select or deselect with space and submit with enter.
+        The `options` will be shown as a nice list. The user may navigate with up and down, select or deselect with
+        space and submit with enter.
 
-        The `options` are either a string, which is used as the display value and the id, or a tuple[str, str], where the first string is the display value and the second is the option's id.
+        The `options` are either a string, which is used as the display value and the id, or a tuple[str, str],
+        where the first string is the display value and the second is the option's id.
 
         :param question: The question to display
         :type question: str
@@ -238,7 +261,8 @@ class Prompt:
         :type pointer_at: int | None, optional
         :param default_checked: A list of ids, which should be checked by default (empty if None)
         :type default_checked: tuple[str, ...] | None, optional
-        :param min_selections: A minimum amount of options that need to be checked before submitting (prohibits the user of submitting, if not enough are checked; 0 if None)
+        :param min_selections: A minimum amount of options that need to be checked before submitting (prohibits the
+        user of submitting, if not enough are checked; 0 if None)
         :type min_selections: int, optional
         :param style: A separate style to style the prompt (empty or None for default style), defaults to None
         :type style: PromptStyle | None, optional
@@ -253,20 +277,23 @@ class Prompt:
             default_checked,
             min_selections,
             layout=Layout(
-                HSplit([
-                    Window(FormattedTextControl(), always_hide_cursor=True),
-                    Window(FormattedTextControl(
-                        HTML(
-                            'Use UP, DOWN to change selection, SPACE to select, ENTER to submit'
-                        )),
-                           char=' ',
-                           style='class:tooltip',
-                           height=1)
-                ])),
+                HSplit(
+                    [
+                        Window(FormattedTextControl(), always_hide_cursor=True),
+                        Window(
+                            FormattedTextControl(
+                                HTML('Use UP, DOWN to change selection, SPACE to select, ENTER to submit')
+                            ),
+                            char=' ',
+                            style='class:tooltip',
+                            height=1
+                        )
+                    ]
+                )
+            ),
             key_bindings=generate_key_bindings(CheckboxPrompt),
             erase_when_done=True,
-            style=convert_style(style)
-            if style else convert_style(default_style),
+            style=convert_style(style) if style else convert_style(default_style),
         )
         ans = app.prompt()
         if ans == None:
@@ -289,7 +316,8 @@ class Prompt:
 
         If `default` is `False`, the prompt will be in the style of (n/Y).
 
-        If `default` is `None` (or not given), the prompt will be in the style of (y/n). In this case, the user may not use enter to submit the default, as there is no default given.
+        If `default` is `None` (or not given), the prompt will be in the style of (y/n). In this case, the user may
+        not use enter to submit the default, as there is no default given.
 
         :param question: The question to display
         :type question: str
@@ -305,20 +333,21 @@ class Prompt:
             question,
             default,
             layout=Layout(
-                HSplit([
-                    Window(FormattedTextControl(), always_hide_cursor=True),
-                    Window(FormattedTextControl(
-                        HTML(
-                            'Press Y or N, ENTER if default value is available'
-                        )),
-                           char=' ',
-                           style='class:tooltip',
-                           height=1)
-                ])),
+                HSplit(
+                    [
+                        Window(FormattedTextControl(), always_hide_cursor=True),
+                        Window(
+                            FormattedTextControl(HTML('Press Y or N, ENTER if default value is available')),
+                            char=' ',
+                            style='class:tooltip',
+                            height=1
+                        )
+                    ]
+                )
+            ),
             key_bindings=generate_key_bindings(ConfirmPrompt),
             erase_when_done=True,
-            style=convert_style(style)
-            if style else convert_style(default_style),
+            style=convert_style(style) if style else convert_style(default_style),
         )
 
         ans = app.prompt()
@@ -342,15 +371,21 @@ class Prompt:
         """
         Ask the user for typing an input.
 
-        If default is given, it will be returned if enter was pressed and no input was given by the user. If the user writes an input, the default will be overwritten.
+        If default is given, it will be returned if enter was pressed and no input was given by the user. If the user
+        writes an input, the default will be overwritten.
 
         If multiline is activated, enter will not submit, but rather create a newline. Use `alt+enter` to submit.
 
-        If show_symbol is given, all chars (except newlines) will be replaced with this character in the interface. The result will still be the input the user typed, it just will not appear in the CLI.
+        If show_symbol is given, all chars (except newlines) will be replaced with this character in the interface.
+        The result will still be the input the user typed, it just will not appear in the CLI.
 
-        Validate takes a function which receives a `str` (the current input of the user) and may return None or a `str`. If the function returns None, the prompt may assume that the input is valid. If it returns a `str`, this will be the error shown to the user. The user will not be able to submit the input, if validate returns an error.
+        Validate takes a function which receives a `str` (the current input of the user) and may return None or a
+        `str`. If the function returns None, the prompt may assume that the input is valid. If it returns a `str`,
+        this will be the error shown to the user. The user will not be able to submit the input, if validate returns
+        an error.
 
-        Completions may be a list of possible completion strings or a nested dictionary where the key is a completion string and the value is a new dict in the same style (more in the README.md).
+        Completions may be a list of possible completion strings or a nested dictionary where the key is a completion
+        string and the value is a new dict in the same style (more in the README.md).
 
         You can use your own Completer as well (more in the README.md).
 
@@ -370,7 +405,8 @@ class Prompt:
         :type completions: list[str] | CompletionDict | None, optional
         :param completer: A completer to use, defaults to None
         :type completer: Completer | None, optional
-        :param completion_show_multicolumn: Whether to show the completions as a scrollable list or as multiple columns, defaults to False
+        :param completion_show_multicolumn: Whether to show the completions as a scrollable list or as multiple
+        columns, defaults to False
         :type completion_show_multicolumn: bool, optional
         :param style: A separate style to style the prompt (empty or None for default style), defaults to None
         :type style: PromptStyle | None, optional
@@ -380,27 +416,27 @@ class Prompt:
         """
 
         # extracting the body, so we can display a floating auto completion field
-        body = HSplit([
-            VSplit([
-                Window(
-                    FormattedTextControl(),
-                    always_hide_cursor=True,
-                    dont_extend_width=True,
+        body = HSplit(
+            [
+                VSplit(
+                    [
+                        Window(
+                            FormattedTextControl(),
+                            always_hide_cursor=True,
+                            dont_extend_width=True,
+                        ),
+                        Window(BufferControl(Buffer(complete_while_typing=True))),
+                        # the completer will be passed in the Application class
+                    ]
                 ),
                 Window(
-                    BufferControl(Buffer(complete_while_typing=True))
-                ),  # the completer will be passed in the Application class
-            ]),
-            Window(
-                FormattedTextControl(
-                    HTML(
-                        f'Type your answer, {"ALT+ENTER" if multiline else "ENTER"} to submit'
-                    )),
-                char=' ',
-                style='class:tooltip',
-                height=1,
-            )
-        ])
+                    FormattedTextControl(HTML(f'Type your answer, {"ALT+ENTER" if multiline else "ENTER"} to submit')),
+                    char=' ',
+                    style='class:tooltip',
+                    height=1,
+                )
+            ]
+        )
 
         app = InputPrompt(
             question,
@@ -415,16 +451,17 @@ class Prompt:
                     content=body,
                     floats=[
                         Float(
-                            MultiColumnCompletionsMenu(show_meta=False) if
-                            completion_show_multicolumn else CompletionsMenu(),
+                            MultiColumnCompletionsMenu(show_meta=False)
+                            if completion_show_multicolumn else CompletionsMenu(),
                             xcursor=True,
                             ycursor=True,
                         )
-                    ])),
+                    ]
+                )
+            ),
             key_bindings=generate_key_bindings(InputPrompt),
             erase_when_done=True,
-            style=convert_style(style)
-            if style else convert_style(default_style),
+            style=convert_style(style) if style else convert_style(default_style),
         )
 
         ans = app.prompt()
@@ -442,7 +479,9 @@ class Prompt:
         """
         Ask the user for filling out the displayed table.
 
-        This method shows the question alongside a table, which the user may navigate with the arrow keys. The user has the ability to use the up, down and enter keys to navigate between the options and change the text in each cell.
+        This method shows the question alongside a table, which the user may navigate with the arrow keys. The user
+        has the ability to use the up, down and enter keys to navigate between the options and change the text in
+        each cell.
 
         The `data` is either a pandas DataFrame or a dictionary.
 
@@ -460,20 +499,26 @@ class Prompt:
             question,
             data,
             layout=Layout(
-                HSplit([
-                    Window(FormattedTextControl()),
-                    Window(FormattedTextControl(
-                        HTML(
-                            'Use UP, DOWN, LEFT, RIGHT to select a cell, TYPE to add char, BACKSPACE to delete char, ENTER to submit'
-                        )),
-                           char=' ',
-                           style='class:tooltip',
-                           height=1)
-                ])),
+                HSplit(
+                    [
+                        Window(FormattedTextControl()),
+                        Window(
+                            FormattedTextControl(
+                                HTML(
+                                    'Use UP, DOWN, LEFT, RIGHT to select a cell, TYPE to add char, BACKSPACE to '
+                                    'delete char, ENTER to submit'
+                                )
+                            ),
+                            char=' ',
+                            style='class:tooltip',
+                            height=1
+                        )
+                    ]
+                )
+            ),
             key_bindings=generate_key_bindings(TablePrompt),
             erase_when_done=True,
-            style=convert_style(style)
-            if style else convert_style(default_style),
+            style=convert_style(style) if style else convert_style(default_style),
         )
         ans = app.prompt()
         # if type(ans) is type(None):

--- a/ItsPrompt/prompt.py
+++ b/ItsPrompt/prompt.py
@@ -32,7 +32,7 @@ from .prompts.raw_select import RawSelectPrompt
 from .prompts.select import SelectPrompt
 from .prompts.table import TablePrompt
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pandas import DataFrame
 
 
@@ -163,7 +163,7 @@ class Prompt:
         allow_keyboard: bool = False,
         style: PromptStyle | None = None,
     ) -> str:
-        '''
+        """
         Ask the user for selecting ONE of the given `options`.
 
         The user needs to type the key of the option. If the user types `h`, all options will be shown.
@@ -185,7 +185,7 @@ class Prompt:
         :raises KeyboardInterrupt: When the user presses ctrl-c, `KeyboardInterrupt` will be raised
         :return: The id of the selected option
         :rtype: str
-        '''
+        """
         app = ExpandPrompt(
             question,
             options,
@@ -223,7 +223,7 @@ class Prompt:
         min_selections: int = 0,
         style: PromptStyle | None = None,
     ) -> list[str]:
-        '''
+        """
         Ask the user for selecting MULTIPLE of the given `options`.
 
         The `options` will be shown as a nice list. The user may navigate with up and down, select or deselect with space and submit with enter.
@@ -245,7 +245,7 @@ class Prompt:
         :raises KeyboardInterrupt: When the user presses ctrl-c, `KeyboardInterrupt` will be raised
         :return: The ids of the selected options
         :rtype: list[str]
-        '''
+        """
         app = CheckboxPrompt(
             question,
             options,
@@ -280,7 +280,7 @@ class Prompt:
         default: bool | None = None,
         style: PromptStyle | None = None,
     ) -> bool:
-        '''
+        """
         Ask the user for confirming or denying your prompt.
 
         The user needs to type "y", "n" or enter (only if default is given).
@@ -300,7 +300,7 @@ class Prompt:
         :raises KeyboardInterrupt: When the user presses ctrl-c, `KeyboardInterrupt` will be raised
         :return: Whether the user selected "y" or "n"
         :rtype: bool
-        '''
+        """
         app = ConfirmPrompt(
             question,
             default,
@@ -339,7 +339,7 @@ class Prompt:
         completion_show_multicolumn: bool = False,
         style: PromptStyle | None = None,
     ) -> str:
-        '''
+        """
         Ask the user for typing an input.
 
         If default is given, it will be returned if enter was pressed and no input was given by the user. If the user writes an input, the default will be overwritten.
@@ -377,7 +377,7 @@ class Prompt:
         :raises KeyboardInterrupt: When the user presses ctrl-c, `KeyboardInterrupt` will be raised
         :return: The input of the user
         :rtype: str
-        '''
+        """
 
         # extracting the body, so we can display a floating auto completion field
         body = HSplit([
@@ -439,7 +439,7 @@ class Prompt:
         data: Union["DataFrame", dict[str, list[str]]],
         style: PromptStyle | None = None,
     ) -> Union["DataFrame", dict[str, list[str]]]:
-        '''
+        """
         Ask the user for filling out the displayed table.
 
         This method shows the question alongside a table, which the user may navigate with the arrow keys. The user has the ability to use the up, down and enter keys to navigate between the options and change the text in each cell.
@@ -455,7 +455,7 @@ class Prompt:
         :raises KeyboardInterrupt: When the user presses ctrl-c, `KeyboardInterrupt` will be raised
         :return: The id of the selected option
         :rtype: str
-        '''
+        """
         app = TablePrompt(
             question,
             data,

--- a/ItsPrompt/prompt.py
+++ b/ItsPrompt/prompt.py
@@ -9,9 +9,8 @@ created by ItsNameless
 
 # mypy: disable-error-code=return-value
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable, Union
 
-from pandas import DataFrame
 from prompt_toolkit import HTML
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.completion import Completer
@@ -32,6 +31,9 @@ from .prompts.input import InputPrompt
 from .prompts.raw_select import RawSelectPrompt
 from .prompts.select import SelectPrompt
 from .prompts.table import TablePrompt
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 
 class Prompt:
@@ -434,23 +436,20 @@ class Prompt:
     def table(
         cls,
         question: str,
-        data: DataFrame,
+        data: Union["DataFrame", dict[str, list[str]]],
         style: PromptStyle | None = None,
-    ) -> DataFrame:
+    ) -> Union["DataFrame", dict[str, list[str]]]:
         '''
         Ask the user for filling out the displayed table.
 
         This method shows the question alongside a table, which the user may navigate with the arrow keys. The user has the ability to use the up, down and enter keys to navigate between the options and change the text in each cell.
 
-        The `data` is a pandas DataFrame, where the values will be input in the cells by default.
+        The `data` is either a pandas DataFrame or a dictionary.
 
-        # TODO
         :param question: The question to display
         :type question: str
-        :param options: A list of possible options
-        :type options: tuple[str  |  tuple[str, str], ...]
-        :param default: The id of the default option to select (empty or None if the first should be default), defaults to None
-        :type default: str | None, optional
+        :param data: The data to display
+        :type data: DataFrame | dict[str, list[str]]
         :param style: A separate style to style the prompt (empty or None for default style), defaults to None
         :type style: PromptStyle | None, optional
         :raises KeyboardInterrupt: When the user presses ctrl-c, `KeyboardInterrupt` will be raised
@@ -477,6 +476,7 @@ class Prompt:
             if style else convert_style(default_style),
         )
         ans = app.prompt()
-        if type(ans) != DataFrame and ans == None:
+        # if type(ans) is type(None):
+        if ans is None:
             raise KeyboardInterrupt()
-        return ans
+        return ans  # type: ignore

--- a/ItsPrompt/prompts/checkbox.py
+++ b/ItsPrompt/prompts/checkbox.py
@@ -72,7 +72,7 @@ class CheckboxPrompt(Application):
             else:
                 content += f'\n<option>    ' \
                            f'{self.__class__.CHECKED_SIGN if option.is_selected else self.__class__.UNCHECKED_SIGN} ' \
-                           f' {option.name} < / option > '
+                           f' {option.name} </option> '
 
                 self.prompt_content.text = HTML(content)
 

--- a/ItsPrompt/prompts/checkbox.py
+++ b/ItsPrompt/prompts/checkbox.py
@@ -1,4 +1,4 @@
-from prompt_toolkit import HTML, Application
+from prompt_toolkit import Application, HTML
 from prompt_toolkit.layout.containers import Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 
@@ -6,7 +6,6 @@ from ..data.checkbox import process_data
 
 
 class CheckboxPrompt(Application):
-
     CHECKED_SIGN = '\u25cf'
     UNCHECKED_SIGN = '\u25cb'
 
@@ -23,14 +22,11 @@ class CheckboxPrompt(Application):
         super().__init__(*args, **kwargs)
 
         # get prompt content box
-        self.prompt_content: FormattedTextControl = self.layout.container.get_children(
-        )[0].content  # type: ignore
+        self.prompt_content: FormattedTextControl = self.layout.container.get_children()[0].content  # type: ignore
 
         # save toolbar window and box (for showing errors)
-        self.toolbar_window: Window = self.layout.container.get_children()[
-            1]  # type: ignore
-        self.toolbar_content: FormattedTextControl = self.layout.container.get_children(
-        )[1].content  # type: ignore
+        self.toolbar_window: Window = self.layout.container.get_children()[1]  # type: ignore
+        self.toolbar_content: FormattedTextControl = self.layout.container.get_children()[1].content  # type: ignore
 
         # save standard toolbar content
         self.toolbar_content_default_text = self.toolbar_content.text
@@ -62,42 +58,45 @@ class CheckboxPrompt(Application):
                     was_set += 1
 
             if was_set != len(default_checked):
-                raise ValueError(
-                    'At least one of the given default_checked values is invalid.'
-                )
+                raise ValueError('At least one of the given default_checked values is invalid.')
 
     def update(self):
-        '''update prompt content'''
+        """update prompt content"""
         content = f'[<question_mark>?</question_mark>] <question>{self.question}</question>:'
 
         for i, option in enumerate(self.options):
             if i == self.selection:
-                content += f'\n<selected_option>  > {self.__class__.CHECKED_SIGN if option.is_selected else self.__class__.UNCHECKED_SIGN} {option.name}</selected_option>'
+                content += f'\n<selected_option>  > ' \
+                           f'{self.__class__.CHECKED_SIGN if option.is_selected else self.__class__.UNCHECKED_SIGN} ' \
+                           f'{option.name}</selected_option>'
             else:
-                content += f'\n<option>    {self.__class__.CHECKED_SIGN if option.is_selected else self.__class__.UNCHECKED_SIGN} {option.name}</option>'
+                content += f'\n<option>    ' \
+                           f'{self.__class__.CHECKED_SIGN if option.is_selected else self.__class__.UNCHECKED_SIGN} ' \
+                           f' {option.name} < / option > '
 
-        self.prompt_content.text = HTML(content)
+                self.prompt_content.text = HTML(content)
 
-        # show error, if error should be shown, else show normal prompt
-        if not self.is_error:
-            # show normal prompt, change style to standard toolbar
-            self.toolbar_content.text = self.toolbar_content_default_text
-            self.toolbar_window.style = 'class:tooltip'
-        else:  # pragma: no cover
-            # show error prompt and error style
-            # the only error that might occur is that not enough options are selected
-            self.toolbar_content.text = f'ERROR: a minimum of {self.min_selections} options need to be selected!'
-            self.toolbar_window.style = 'class:error'
+                # show error, if error should be shown, else show normal prompt
+                if not self.is_error:
+                    # show normal prompt, change style to standard toolbar
+                    self.toolbar_content.text = self.toolbar_content_default_text
+                    self.toolbar_window.style = 'class:tooltip'
+                else:  # pragma: no cover
+                    # show error prompt and error style
+                    # the only error that might occur is that not enough options are selected
+                    self.toolbar_content.text = f'ERROR: a minimum of {self.min_selections} options need to be ' \
+                                                f'selected!'
+                    self.toolbar_window.style = 'class:error'
 
     def prompt(self) -> list[str] | None:
-        '''start the application, returns the return value'''
+        """start the application, returns the return value"""
         self.update()
         out: list[str] | None = self.run()
 
         return out
 
     def on_up(self):
-        '''when up is pressed, the previous indexed option will be selected'''
+        """when up is pressed, the previous indexed option will be selected"""
         self.selection = (self.selection - 1) % len(self.options)
 
         # reset error
@@ -106,7 +105,7 @@ class CheckboxPrompt(Application):
         self.update()
 
     def on_down(self):
-        '''when down is pressed, the next indexed option will be selected'''
+        """when down is pressed, the next indexed option will be selected"""
         self.selection = (self.selection + 1) % len(self.options)
 
         # reset error
@@ -115,9 +114,8 @@ class CheckboxPrompt(Application):
         self.update()
 
     def on_space(self):
-        '''when space is pressed, select or deselect current selection'''
-        self.options[self.selection].is_selected = not self.options[
-            self.selection].is_selected
+        """when space is pressed, select or deselect current selection"""
+        self.options[self.selection].is_selected = not self.options[self.selection].is_selected
 
         # reset error
         self.is_error = False

--- a/ItsPrompt/prompts/confirm.py
+++ b/ItsPrompt/prompts/confirm.py
@@ -1,4 +1,4 @@
-from prompt_toolkit import HTML, Application
+from prompt_toolkit import Application, HTML
 from prompt_toolkit.layout.containers import Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 
@@ -15,14 +15,11 @@ class ConfirmPrompt(Application):
         super().__init__(*args, **kwargs)
 
         # get prompt content box
-        self.prompt_content: FormattedTextControl = self.layout.container.get_children(
-        )[0].content  # type: ignore
+        self.prompt_content: FormattedTextControl = self.layout.container.get_children()[0].content  # type: ignore
 
         # save toolbar window and box (for showing errors)
-        self.toolbar_window: Window = self.layout.container.get_children()[
-            1]  # type: ignore
-        self.toolbar_content: FormattedTextControl = self.layout.container.get_children(
-        )[1].content  # type: ignore
+        self.toolbar_window: Window = self.layout.container.get_children()[1]  # type: ignore
+        self.toolbar_content: FormattedTextControl = self.layout.container.get_children()[1].content  # type: ignore
 
         # save standard toolbar content
         self.toolbar_content_default_text = self.toolbar_content.text
@@ -37,8 +34,9 @@ class ConfirmPrompt(Application):
         self.default = default
 
     def update(self):
-        '''update prompt content'''
-        content = f'[<question_mark>?</question_mark>] <question>{self.question}</question>: <text>({"Y" if self.default==True else "y"}/{"N" if self.default==False else "n"})</text>'
+        """update prompt content"""
+        content = f'[<question_mark>?</question_mark>] <question>{self.question}</question>: <text>(' \
+                  f'{"Y" if self.default == True else "y"}/{"N" if self.default == False else "n"})</text>'
 
         self.prompt_content.text = HTML(content)
 
@@ -54,14 +52,14 @@ class ConfirmPrompt(Application):
             self.toolbar_window.style = 'class:error'
 
     def prompt(self) -> bool | None:
-        '''start the application, returns the return value'''
+        """start the application, returns the return value"""
         self.update()
         out: bool | None = self.run()
 
         return out
 
     def on_key(self, key_sequence: list[str]):
-        '''when Y or N is pressed, select value and submit'''
+        """when Y or N is pressed, select value and submit"""
         key = key_sequence[0]
 
         # return if key is not an available key

--- a/ItsPrompt/prompts/expand.py
+++ b/ItsPrompt/prompts/expand.py
@@ -1,4 +1,4 @@
-from prompt_toolkit import HTML, Application
+from prompt_toolkit import Application, HTML
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 from ..data.expand import process_data
@@ -18,8 +18,7 @@ class ExpandPrompt(Application):
         super().__init__(*args, **kwargs)
 
         # get prompt content box
-        self.prompt_content: FormattedTextControl = self.layout.container.get_children(
-        )[0].content  # type: ignore
+        self.prompt_content: FormattedTextControl = self.layout.container.get_children()[0].content  # type: ignore
 
         # save question
         self.question = question
@@ -49,7 +48,7 @@ class ExpandPrompt(Application):
             raise ValueError('Default value is not a valid id.')
 
     def update(self):
-        '''update prompt content'''
+        """update prompt content"""
         # question
         content = f'[<question_mark>?</question_mark>] <question>{self.question}</question>: <text>({self.keys})</text>'
 
@@ -67,37 +66,35 @@ class ExpandPrompt(Application):
         self.prompt_content.text = HTML(content)
 
     def prompt(self) -> str | None:
-        '''start the application, returns the return value'''
+        """start the application, returns the return value"""
         self.update()
         out: str | None = self.run()
 
         return out
 
     def on_up(self):
-        '''when up is pressed, the previous indexed option will be selected'''
+        """when up is pressed, the previous indexed option will be selected"""
         if not self.allow_keyboard:
             return
 
-        self.selection = self.keys[(self.keys.index(self.selection) - 1) %
-                                   len(self.keys)]
+        self.selection = self.keys[(self.keys.index(self.selection) - 1) % len(self.keys)]
 
         self.update()
 
     def on_down(self):
-        '''when down is pressed, the next indexed option will be selected'''
+        """when down is pressed, the next indexed option will be selected"""
         if not self.allow_keyboard:
             return
 
-        self.selection = self.keys[(self.keys.index(self.selection) + 1) %
-                                   len(self.keys)]
+        self.selection = self.keys[(self.keys.index(self.selection) + 1) % len(self.keys)]
 
         self.update()
 
     def on_key(self, key_sequence: list[str]):
-        '''when a index is pressed, which is available to select, select this index'''
+        """when an index is pressed, which is available to select, select this index"""
         key = key_sequence[0]
 
-        # return if key is not a an available key
+        # return if key is not an available key
         if not key in self.keys:
             return
 

--- a/ItsPrompt/prompts/input.py
+++ b/ItsPrompt/prompts/input.py
@@ -1,10 +1,13 @@
-import string
 from typing import Callable
 
-from prompt_toolkit import HTML, Application
+from prompt_toolkit import Application, HTML
 from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.completion import (Completer, FuzzyCompleter,
-                                       FuzzyWordCompleter, NestedCompleter)
+from prompt_toolkit.completion import (
+    Completer,
+    FuzzyCompleter,
+    FuzzyWordCompleter,
+    NestedCompleter,
+)
 from prompt_toolkit.layout.containers import Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.processors import PasswordProcessor
@@ -33,8 +36,7 @@ class InputPrompt(Application):
         _vsplit = _body[0].get_children()
 
         # get prompt content box
-        self.prompt_content: FormattedTextControl = _vsplit[
-            0].content  # type: ignore
+        self.prompt_content: FormattedTextControl = _vsplit[0].content  # type: ignore
 
         # get input buffer
         self.buffer: Buffer = _vsplit[1].content.buffer  # type: ignore
@@ -66,9 +68,7 @@ class InputPrompt(Application):
 
         # when show_symbol is given, use PasswordProcessor to show the symbol instead of the text
         if self.show_symbol:
-            _vsplit[1].content.input_processors = [
-                PasswordProcessor(self.show_symbol)
-            ]
+            _vsplit[1].content.input_processors = [PasswordProcessor(self.show_symbol)]
 
         # save validator function
         self.validate = validate
@@ -77,14 +77,11 @@ class InputPrompt(Application):
         self.completer: None | Completer = None
 
         if completions and completer:
-            raise ValueError(
-                'completions and completer are mutually exclusive! Please use only one of them!'
-            )
+            raise ValueError("completions and completer are mutually exclusive! Please use only one of them!")
 
         if show_symbol and (completions or completer):
             # symbol and completer are mutually exclusive
-            raise ValueError(
-                'Completions are not compatible with show_symbol!')
+            raise ValueError('Completions are not compatible with show_symbol!')
 
         if completions:  # pragma: no cover
             # a list or a dict of completions to use is given
@@ -93,8 +90,7 @@ class InputPrompt(Application):
                 self.completer = FuzzyWordCompleter(list(completions))
             elif type(completions) is dict:
                 # we use FuzzyCompleter with NestedCompleter
-                self.completer = FuzzyCompleter(
-                    NestedCompleter.from_nested_dict(completions))
+                self.completer = FuzzyCompleter(NestedCompleter.from_nested_dict(completions))
 
         elif completer:  # pragma: no cover
             # a self-created completer is given
@@ -105,7 +101,7 @@ class InputPrompt(Application):
             self.buffer.completer = self.completer
 
     def update(self):  # pragma: no cover
-        '''update prompt content'''
+        """update prompt content"""
         content = f'[<question_mark>?</question_mark>] <question>{self.question}</question>: '
 
         if self.default and self.buffer.text == '':
@@ -140,14 +136,14 @@ class InputPrompt(Application):
             self.buffer.start_completion()
 
     def prompt(self) -> str | None:
-        '''start the application, returns the return value'''
+        """start the application, returns the return value"""
         self.update()
         out: str | None = self.run()
 
         return out
 
     def _submit(self):
-        '''method for submitting result, as this is done by two functions'''
+        """method for submitting result, as this is done by two functions"""
         # if an error is currently shown, prevent submit
         if self.is_error:  # pragma: no cover
             return
@@ -161,15 +157,15 @@ class InputPrompt(Application):
             self.exit(result='')
 
     def on_alt_enter(self):
-        '''if multiline is enabled, this will submit'''
+        """if multiline is enabled, this will submit"""
         if self.multiline:
             self._submit()
 
     def on_enter(self):
-        '''either submit key or in multiline, append new line'''
+        """either submit key or in multiline, append new line"""
         # run completion
-        if (self.is_running) and self.buffer.complete_state and (
-                completion := self.buffer.complete_state.current_completion
+        if self.is_running and self.buffer.complete_state and (
+            completion := self.buffer.complete_state.current_completion
         ):  # pragma: no cover
             self.buffer.apply_completion(completion)
 

--- a/ItsPrompt/prompts/raw_select.py
+++ b/ItsPrompt/prompts/raw_select.py
@@ -1,4 +1,4 @@
-from prompt_toolkit import HTML, Application
+from prompt_toolkit import Application, HTML
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 from ..data.select import process_data
@@ -18,8 +18,7 @@ class RawSelectPrompt(Application):
         super().__init__(*args, **kwargs)
 
         # get prompt content box
-        self.prompt_content: FormattedTextControl = self.layout.container.get_children(
-        )[0].content  # type: ignore
+        self.prompt_content: FormattedTextControl = self.layout.container.get_children()[0].content  # type: ignore
 
         # save question
         self.question = question
@@ -43,31 +42,31 @@ class RawSelectPrompt(Application):
             raise ValueError('Default value is not a valid id.')
 
     def update(self):
-        '''update prompt content'''
+        """update prompt content"""
         # question
         content = f'[<question_mark>?</question_mark>] <question>{self.question}</question>:'
 
         # options
         for i, option in enumerate(self.options):
             if i == self.selection:
-                content += f'\n<selected_option>    {i+1}) {option.name}</selected_option>'
+                content += f'\n<selected_option>    {i + 1}) {option.name}</selected_option>'
             else:
-                content += f'\n<option>    {i+1}) {option.name}</option>'
+                content += f'\n<option>    {i + 1}) {option.name}</option>'
 
         # text
-        content += f'\n<text>    Answer: {self.selection+1}</text>'
+        content += f'\n<text>    Answer: {self.selection + 1}</text>'
 
         self.prompt_content.text = HTML(content)
 
     def prompt(self) -> str | None:
-        '''start the application, returns the return value'''
+        """start the application, returns the return value"""
         self.update()
         out: str | None = self.run()
 
         return out
 
     def on_up(self):
-        '''when up is pressed, the previous indexed option will be selected'''
+        """when up is pressed, the previous indexed option will be selected"""
         if not self.allow_keyboard:
             return
 
@@ -76,7 +75,7 @@ class RawSelectPrompt(Application):
         self.update()
 
     def on_down(self):
-        '''when down is pressed, the next indexed option will be selected'''
+        """when down is pressed, the next indexed option will be selected"""
         if not self.allow_keyboard:
             return
 
@@ -85,7 +84,7 @@ class RawSelectPrompt(Application):
         self.update()
 
     def on_key(self, key_sequence: list[str]):
-        '''when a index is pressed, which is available to select, select this index'''
+        """when an index is pressed, which is available to select, select this index"""
         key = key_sequence[0]
 
         # return if key is not a number

--- a/ItsPrompt/prompts/select.py
+++ b/ItsPrompt/prompts/select.py
@@ -1,4 +1,4 @@
-from prompt_toolkit import HTML, Application
+from prompt_toolkit import Application, HTML
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 from ..data.select import process_data
@@ -17,8 +17,7 @@ class SelectPrompt(Application):
         super().__init__(*args, **kwargs)
 
         # get prompt content box
-        self.prompt_content: FormattedTextControl = self.layout.container.get_children(
-        )[0].content  # type: ignore
+        self.prompt_content: FormattedTextControl = self.layout.container.get_children()[0].content  # type: ignore
 
         # save question
         self.question = question
@@ -39,7 +38,7 @@ class SelectPrompt(Application):
             raise ValueError('Default value is not a valid id.')
 
     def update(self):
-        '''update prompt content'''
+        """update prompt content"""
         content = f'[<question_mark>?</question_mark>] <question>{self.question}</question>:'
 
         for i, option in enumerate(self.options):
@@ -51,20 +50,20 @@ class SelectPrompt(Application):
         self.prompt_content.text = HTML(content)
 
     def prompt(self) -> str | None:
-        '''start the application, returns the return value'''
+        """start the application, returns the return value"""
         self.update()
         out: str | None = self.run()
 
         return out
 
     def on_up(self):
-        '''when up is pressed, the previous indexed option will be selected'''
+        """when up is pressed, the previous indexed option will be selected"""
         self.selection = (self.selection - 1) % len(self.options)
 
         self.update()
 
     def on_down(self):
-        '''when down is pressed, the next indexed option will be selected'''
+        """when down is pressed, the next indexed option will be selected"""
         self.selection = (self.selection + 1) % len(self.options)
 
         self.update()

--- a/ItsPrompt/prompts/table.py
+++ b/ItsPrompt/prompts/table.py
@@ -7,18 +7,18 @@ from prompt_toolkit.layout.controls import FormattedTextControl
 
 from ..data.table import Table
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pandas import DataFrame
 
 
 class TablePrompt(Application):
 
     def __init__(
-        self,
-        question: str,
-        data: Union["DataFrame", dict[str, list[str]]],
-        *args,
-        **kwargs,
+            self,
+            question: str,
+            data: Union["DataFrame", dict[str, list[str]]],
+            *args,
+            **kwargs,
     ):
         super().__init__(*args, **kwargs)
 
@@ -40,7 +40,7 @@ class TablePrompt(Application):
         )
 
     def update(self):
-        '''update prompt content'''
+        """update prompt content"""
         content = f'[<question_mark>?</question_mark>] <question>{self.question}</question>:\n'
 
         # append table
@@ -51,45 +51,45 @@ class TablePrompt(Application):
         self.prompt_content.text = HTML(content)
 
     def prompt(self) -> Union["DataFrame", dict[str, list[str]], None]:
-        '''start the application, returns the return value'''
+        """start the application, returns the return value"""
         self.update()
         out: Union["DataFrame", dict[str, list[str]], None] = self.run()
 
         return out
 
     def on_up(self):
-        '''when up is pressed, the cell one above will be selected'''
+        """when up is pressed, the cell one above will be selected"""
         self.table.on_up()
 
         self.update()
 
     def on_down(self):
-        '''when down is pressed, the cell one below will be selected'''
+        """when down is pressed, the cell one below will be selected"""
         self.table.on_down()
 
         self.update()
 
     def on_left(self):
-        '''when left is pressed, the cell one to the left will be selected'''
+        """when left is pressed, the cell one to the left will be selected"""
         self.table.on_left()
 
         self.update()
 
     def on_right(self):
-        '''when left is pressed, the cell one to the right will be selected'''
+        """when left is pressed, the cell one to the right will be selected"""
         self.table.on_right()
 
         self.update()
 
     def on_key(self, key_sequence: list[str]):
-        '''when a key is pressed, the key will be added to the current cells content'''
+        """when a key is pressed, the key will be added to the current cells content"""
         key = key_sequence[0]
         self.table.add_key(key)
 
         self.update()
 
     def on_backspace(self):
-        '''when backspace is pressed, the last char will be removed from the current cells content'''
+        """when backspace is pressed, the last char will be removed from the current cells content"""
         self.table.del_key()
 
         self.update()

--- a/ItsPrompt/prompts/table.py
+++ b/ItsPrompt/prompts/table.py
@@ -1,11 +1,14 @@
 import html
+from typing import TYPE_CHECKING, Union
 
-from pandas import DataFrame
 from prompt_toolkit import HTML, Application
 from prompt_toolkit.data_structures import Point
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 from ..data.table import Table
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 
 class TablePrompt(Application):
@@ -13,7 +16,7 @@ class TablePrompt(Application):
     def __init__(
         self,
         question: str,
-        data: DataFrame,
+        data: Union["DataFrame", dict[str, list[str]]],
         *args,
         **kwargs,
     ):
@@ -47,10 +50,10 @@ class TablePrompt(Application):
 
         self.prompt_content.text = HTML(content)
 
-    def prompt(self) -> DataFrame | None:
+    def prompt(self) -> Union["DataFrame", dict[str, list[str]], None]:
         '''start the application, returns the return value'''
         self.update()
-        out: DataFrame | None = self.run()
+        out: Union["DataFrame", dict[str, list[str]], None] = self.run()
 
         return out
 
@@ -93,4 +96,4 @@ class TablePrompt(Application):
 
     def on_enter(self):
         # return the modified table
-        self.exit(result=self.table.data)
+        self.exit(result=self.table.data.get_data())

--- a/ItsPrompt/prompts/table.py
+++ b/ItsPrompt/prompts/table.py
@@ -1,7 +1,7 @@
 import html
 from typing import TYPE_CHECKING, Union
 
-from prompt_toolkit import HTML, Application
+from prompt_toolkit import Application, HTML
 from prompt_toolkit.data_structures import Point
 from prompt_toolkit.layout.controls import FormattedTextControl
 
@@ -14,17 +14,16 @@ if TYPE_CHECKING:  # pragma: no cover
 class TablePrompt(Application):
 
     def __init__(
-            self,
-            question: str,
-            data: Union["DataFrame", dict[str, list[str]]],
-            *args,
-            **kwargs,
+        self,
+        question: str,
+        data: Union["DataFrame", dict[str, list[str]]],
+        *args,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
 
         # get prompt content box
-        self.prompt_content: FormattedTextControl = self.layout.container.get_children(
-        )[0].content  # type: ignore
+        self.prompt_content: FormattedTextControl = self.layout.container.get_children()[0].content  # type: ignore
 
         # save question
         self.question = question
@@ -35,8 +34,7 @@ class TablePrompt(Application):
         # set cursor
         self.prompt_content.get_cursor_position = lambda: Point(
             self.table.get_current_cursor_position()[0],
-            self.table.get_current_cursor_position()[1] +
-            1,  # add 1 offset for height of question
+            self.table.get_current_cursor_position()[1] + 1,  # add 1 offset for height of question
         )
 
     def update(self):
@@ -46,7 +44,7 @@ class TablePrompt(Application):
         # append table
         content += html.escape(
             self.table.get_table_as_str()
-        )  # escaping is needed so formatting from PromptToolkit wont destroy the whole table
+        )  # escaping is needed so formatting from PromptToolkit won't destroy the whole table
 
         self.prompt_content.text = HTML(content)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Do you ever feel the need to ask a user of your code for an input?
 
-Using `input()` is easy, but is it great? 
+Using `input()` is easy, but is it great?
 
 Do you want to give the user a selection list, a yes-or-no question, or maybe a multiline input field?
 
@@ -22,43 +22,50 @@ And do you think all of this should be done easily, without caring to much how i
 
 Then you are right here! **ItsPrompt** gives you the ability to ask the user for input, the *fancy* way.
 
-**ItsPrompt** tries to be an easy-to-use module for managing prompts for the user. You task is to create a great program, not how to ask the user for input. That is why **ItsPrompt** is there to take care of this problem, so you can focus on the important things!
+**ItsPrompt** tries to be an easy-to-use module for managing prompts for the user. You task is to create a great
+program, not how to ask the user for input. That is why **ItsPrompt** is there to take care of this problem, so you can
+focus on the important things!
 
 # TOC
 
 - [ItsPrompt](#itsprompt)
 - [TOC](#toc)
     - [A small, thankful note](#a-small-thankful-note)
-  - [Features](#features)
-  - [Installation](#installation)
-  - [Usage](#usage)
-  - [Prompt types](#prompt-types)
-    - [`select`](#select)
-    - [`raw_select`](#raw_select)
-    - [`expand`](#expand)
-    - [`checkbox`](#checkbox)
-    - [`confirm`](#confirm)
-    - [`input`](#input)
-    - [`table`](#table)
-  - [Additional Features and Tips](#additional-features-and-tips)
-    - [Options](#options)
-    - [Data](#data)
-    - [Styling](#styling)
-    - [Prompt Validation](#prompt-validation)
-    - [Prompt Completion](#prompt-completion)
-    - [Further Information](#further-information)
+    - [Features](#features)
+    - [Installation](#installation)
+    - [Usage](#usage)
+    - [Prompt types](#prompt-types)
+        - [`select`](#select)
+        - [`raw_select`](#raw_select)
+        - [`expand`](#expand)
+        - [`checkbox`](#checkbox)
+        - [`confirm`](#confirm)
+        - [`input`](#input)
+        - [`table`](#table)
+    - [Additional Features and Tips](#additional-features-and-tips)
+        - [Options](#options)
+        - [Data](#data)
+        - [Styling](#styling)
+        - [Prompt Validation](#prompt-validation)
+        - [Prompt Completion](#prompt-completion)
+        - [Further Information](#further-information)
 
 ---
 
 ### A small, thankful note
 
-This project is not the first to accomplish the above mentioned tasks. There is another package, `PyInquirer`, which inspired me to build **ItsPrompt**.
+This project is not the first to accomplish the above mentioned tasks. There is another package, `PyInquirer`, which
+inspired me to build **ItsPrompt**.
 
-On my way to create a small program I came to a point were I needed a simple GUI, and I tried `PyInquirer`. Unfortunately, at the current time it is not actively maintained and a bit outdated. I thought of updating it, but then I thought "*Isn't it easier to just create my own version?*" - And so I did!
+On my way to create a small program I came to a point were I needed a simple GUI, and I tried `PyInquirer`.
+Unfortunately, at the current time it is not actively maintained and a bit outdated. I thought of updating it, but then
+I thought "*Isn't it easier to just create my own version?*" - And so I did!
 
-**ItsPrompt** is not a copy or a fork of `PyInquirer`. I built this module from the ground up, without ever looking deep into the source code of `PyInquirer`.
+**ItsPrompt** is not a copy or a fork of `PyInquirer`. I built this module from the ground up, without ever looking deep
+into the source code of `PyInquirer`.
 
-On my way to build this package, I learned a lot about `prompt-toolkit`, and all of this just because of `PyInquirer`! Thanks!
+On my way to build this package, I learned a lot about `prompt-toolkit`, and all of this just because of `PyInquirer`!
+Thanks!
 
 ---
 
@@ -126,7 +133,6 @@ Prompt.select(
 ```
 
 *additional information on the function arguments can be found in the docstring*
-
 
 ### `raw_select`
 
@@ -231,9 +237,10 @@ Prompt.table(
 
 ### Options
 
-The `options` is always a `tuple` containing `str` and `tuple` objects. 
+The `options` is always a `tuple` containing `str` and `tuple` objects.
 
-If an option is given as a `str`, this will be used as the options display name and the id, which will be returned when selecting this option.
+If an option is given as a `str`, this will be used as the options display name and the id, which will be returned when
+selecting this option.
 
 *In case of `expand`, the first character of the `str` will be used as its key.*
 
@@ -247,21 +254,27 @@ If an option is given as a `tuple`, the first value will be the options name, th
 
 The `table` prompt takes a mandatory `data` argument, which needs to be a `pandas.DataFrame`.
 
-This `DataFrame` is used as the content of the table. The user may change the fields of the table. The output of the `table` prompt is a `pandas.DataFrame` with the user given values.
+This `DataFrame` is used as the content of the table. The user may change the fields of the table. The output of
+the `table` prompt is a `pandas.DataFrame` with the user given values.
 
-Currently, the output will convert all input values to a `str`, so `int`, `bool`, ... will be converted to strings. This is a current limitation of the way the table is displayed, but may later be updated.
+Currently, the output will convert all input values to a `str`, so `int`, `bool`, ... will be converted to strings. This
+is a current limitation of the way the table is displayed, but may later be updated.
 
-Another limitation of the `table` prompt is the use of styling in the `DataFrame` fields. All styling tags will be displayed as-is, so a `<u>...</u>` will not be underlined, but rather displayed as its shown.
+Another limitation of the `table` prompt is the use of styling in the `DataFrame` fields. All styling tags will be
+displayed as-is, so a `<u>...</u>` will not be underlined, but rather displayed as its shown.
 
 ---
 
 ### Styling
 
-**ItsPrompt** uses `prompt-toolkit` for its prompts. This module not only provides an easy way to interact with the command line, but also a full set of styling features.
+**ItsPrompt** uses `prompt-toolkit` for its prompts. This module not only provides an easy way to interact with the
+command line, but also a full set of styling features.
 
-You can learn more about the available styling features in the documentation of `prompt-toolkit`: [Styling](https://python-prompt-toolkit.readthedocs.io/en/master/pages/printing_text.html#formatted-text).
+You can learn more about the available styling features in the documentation
+of `prompt-toolkit`: [Styling](https://python-prompt-toolkit.readthedocs.io/en/master/pages/printing_text.html#formatted-text).
 
-**ItsPrompt** makes it a bit easier for you to style each component of a prompt. For every component, we give a separate attribute in the `PromptStyle` class, which you can style with valid `prompt-toolkit` styling:
+**ItsPrompt** makes it a bit easier for you to style each component of a prompt. For every component, we give a separate
+attribute in the `PromptStyle` class, which you can style with valid `prompt-toolkit` styling:
 
 ```py
 # examples for the different styling class components
@@ -284,19 +297,18 @@ Prompt.input(
 
 ![](https://raw.githubusercontent.com/TheItsProjects/ItsPrompt/main/media/styling_input_annotated.png)
 
-| ID  |    styling tag    |             default style             |
-| --- | ----------------- | ------------------------------------- |
-| 1   | `question_mark`   | `fg:ansigreen`                        |
-| 2   | `question`        | *                                     |
-| 3   | `option`          | *                                     |
-| 4   | `selected_option` | `fg:ansicyan`                         |
-| 5   | `tooltip`         | `fg:ansibrightblue bg:ansiwhite bold` |
-| 6   | `text`            | *                                     |
-| 7   | `grayout`          | `fg:ansibrightblack`                  |
-| 8   | `error`           | `fg:ansiwhite bg:ansired bold`        |
+| ID | styling tag       | default style                         |
+|----|-------------------|---------------------------------------|
+| 1  | `question_mark`   | `fg:ansigreen`                        |
+| 2  | `question`        | *                                     |
+| 3  | `option`          | *                                     |
+| 4  | `selected_option` | `fg:ansicyan`                         |
+| 5  | `tooltip`         | `fg:ansibrightblue bg:ansiwhite bold` |
+| 6  | `text`            | *                                     |
+| 7  | `grayout`         | `fg:ansibrightblack`                  |
+| 8  | `error`           | `fg:ansiwhite bg:ansired bold`        |
 
 *\*These values are not changed from the default `prompt-toolkit` values.*
-
 
 To create your own style, there are two ways:
 
@@ -314,7 +326,8 @@ This will automatically change the style of all prompts, which do not have an ow
 
 ***Creating your own style***
 
-To define your own style for a specific prompt, import `PromptStyle` and create an object. Then assign it to the `style` argument of a prompt.
+To define your own style for a specific prompt, import `PromptStyle` and create an object. Then assign it to the `style`
+argument of a prompt.
 
 ```py
 from ItsPrompt.data.style import PromptStyle
@@ -325,7 +338,9 @@ my_style = PromptStyle(
 )
 ```
 
-All styles which are not given, **will not** be the same as the default style. Instead they will use the styling given by `prompt-toolkit`. If you want to change our default styles, then copy the `default_style` and change your values, instead of directly creating your own style:
+All styles which are not given, **will not** be the same as the default style. Instead they will use the styling given
+by `prompt-toolkit`. If you want to change our default styles, then copy the `default_style` and change your values,
+instead of directly creating your own style:
 
 ```py
 from ItsPrompt.data.style import create_from_default
@@ -335,15 +350,18 @@ my_style = create_from_default()
 my_style.error = 'fg:ansired bg:ansiwhite'
 ```
 
-> Warning! Not copying the default style and changing it instead will result in all prompts using your changes, as a variable is by default not a copy, but a reference to the same object!
+> Warning! Not copying the default style and changing it instead will result in all prompts using your changes, as a
+> variable is by default not a copy, but a reference to the same object!
 
 ---
 
 ### Prompt Validation
 
-The `input` allows you to validate the input before submitting it. For every character the user types, the validation will be run and a friendly error will be shown in the toolbar.
+The `input` allows you to validate the input before submitting it. For every character the user types, the validation
+will be run and a friendly error will be shown in the toolbar.
 
-To use the validation feature, create a function which takes a `str` as an argument and returns either a `str` or `None`.
+To use the validation feature, create a function which takes a `str` as an argument and returns either a `str`
+or `None`.
 
 ```py
 def input_not_empty(input: str) -> str | None:
@@ -361,13 +379,14 @@ The `str` argument will be the current user input, which can then be checked, bu
 
 If you want to show that the validation succeeded, return `None` (or nothing). This will not trigger any errors.
 
-If you want to show an error, return a `str` with the errors text. Your text will be shown in the toolbar. As long as the validation returns a `str`, the user may not submit the input.
+If you want to show an error, return a `str` with the errors text. Your text will be shown in the toolbar. As long as
+the validation returns a `str`, the user may not submit the input.
 
 ---
 
 ### Prompt Completion
 
-The `input` prompt type supports auto completion as well. 
+The `input` prompt type supports auto completion as well.
 
 > If you use a completer, you are unable to use `show_symbol`!
 
@@ -387,7 +406,8 @@ prompt.input(
 
 ***Creating a nested dictionary of possible completions***
 
-You can use a dictionary for nested completions. Each "layer" will be a completion, after the first was accepted. For example:
+You can use a dictionary for nested completions. Each "layer" will be a completion, after the first was accepted. For
+example:
 
 ```py
 completions = {
@@ -409,7 +429,8 @@ prompt.input(
 )
 ```
 
-The key of each entry is the completion that will be shown. The key is either None if there are no further completions or a new dict, where the key is the completion and the value is the next "layer", and so on...
+The key of each entry is the completion that will be shown. The key is either None if there are no further completions
+or a new dict, where the key is the completion and the value is the next "layer", and so on...
 
 > For more information, the type signature of `CompletionDict` is:  
 > `dict[str, "CompletionDict | None"]`
@@ -418,7 +439,9 @@ The key of each entry is the completion that will be shown. The key is either No
 
 In the background your completions will be mapped to a `Completer`, provided by `prompt-toolkit`.
 
-If you need more customization, you can use a `Completer` given by `prompt-toolkit` or create your own completer. For more information on this process, read here: [Completions in prompt-toolkit](https://python-prompt-toolkit.readthedocs.io/en/stable/pages/asking_for_input.html#autocompletion).
+If you need more customization, you can use a `Completer` given by `prompt-toolkit` or create your own completer. For
+more information on this process, read
+here: [Completions in prompt-toolkit](https://python-prompt-toolkit.readthedocs.io/en/stable/pages/asking_for_input.html#autocompletion).
 
 There are a number of completers available, for example:
 
@@ -427,9 +450,10 @@ There are a number of completers available, for example:
 - `ExecutableCompleter`
     - automatically complete executables in file system
 - `WordCompleter`
-    - As simple as it can get. Just completes the letters of the word, that are actually present (the `FuzzyCompleter` which `completions` uses in background completes based on a probability, and may show matches which are not exact).
+    - As simple as it can get. Just completes the letters of the word, that are actually present (the `FuzzyCompleter`
+      which `completions` uses in background completes based on a probability, and may show matches which are not
+      exact).
 - ...
-
 
 To add your own completer to an input field, you can use the `completer` argument:
 
@@ -452,6 +476,7 @@ If you need some easy examples, refer to [example.py](example.py)!
 If you want to contribute, check out the projects repository: [ItsPrompt](https://github.com/TheItsProjects/ItsPrompt)!
 
 If you got any other questions, or want to give an idea on how to improve **ItsPrompt**:
+
 - visit our discussions: [ItsPrompt Discussions](https://github.com/TheItsProjects/ItsPrompt/discussions)!
 - join our discord: [TheItsProjects](https://discord.gg/rP9Qke2jDs)!
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,13 +7,14 @@ This page helps you find out how and when to report security vulnerabilites you 
 Currently we do not have different versions of `ItsPrompt`, so all of the minor versions of `1.x` are supported.
 
 | Version | Supported          |
-| ------- | ------------------ |
+|---------|--------------------|
 | 1.x     | :white_check_mark: |
 
 ## Reporting a Vulnerability
 
 You found a security vulnerability?
 
-No problem! Open an Issue over at [select an Issue type](https://github.com/TheItsProjects/ItsPrompt/issues/new/choose) and choose **Security Vulnerability**. Fill in the required information and then we will look into it!
+No problem! Open an Issue over at [select an Issue type](https://github.com/TheItsProjects/ItsPrompt/issues/new/choose)
+and choose **Security Vulnerability**. Fill in the required information and then we will look into it!
 
 If you want to privately report an Issue, visit our [Discord Server](https://discord.gg/rP9Qke2jDs) for more info!

--- a/example.py
+++ b/example.py
@@ -2,6 +2,7 @@
 
 try:
     from pandas import DataFrame
+
     NO_PANDAS = False
 except ModuleNotFoundError:
     NO_PANDAS = True
@@ -28,7 +29,7 @@ print(ans)
 ans = Prompt.checkbox(
     'What beverages would you like?',
     ('Coke', 'Water', 'Juice'),
-    default_checked=('Water', ),
+    default_checked=('Water',),
     min_selections=1,
 )
 print(ans)

--- a/example.py
+++ b/example.py
@@ -1,6 +1,10 @@
 # mypy: disable-error-code=assignment
 
-from pandas import DataFrame
+try:
+    from pandas import DataFrame
+    NO_PANDAS = False
+except ModuleNotFoundError:
+    NO_PANDAS = True
 
 from ItsPrompt.prompt import Prompt
 
@@ -78,17 +82,18 @@ ans = Prompt.confirm(
 print(ans)
 
 # table
-data = DataFrame({
-    'Food': ['Pizza', 'Burger', 'Salad'],
-    'Qty': [1, 0, 0],
-})
+if not NO_PANDAS:
+    data = DataFrame({
+        'Food': ['Pizza', 'Burger', 'Salad'],
+        'Qty': [1, 0, 0],
+    })
 
-ans = Prompt.table(
-    'Please fill in your quantity',
-    data,
-)
+    ans = Prompt.table(
+        'Please fill in your quantity',
+        data,
+    )
 
-print(ans)
+    print(ans)
 
 # styling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "prompt-toolkit>=3.0.37,<4.0",
-    "pandas>=1.5.3",
 ]
 classifiers = [
         "Programming Language :: Python :: 3",
@@ -33,6 +32,9 @@ include = [
     "ItsPrompt",
     "ItsPrompt.*",
 ]
+
+[options.extras_require]
+df = "pandas>=1.5.3"
 
 [tool.pytest.ini_options]
 addopts = "--cov=ItsPrompt --cov-report term-missing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ItsPrompt"
 version = "1.3"
 authors = [
-    {name = "ItsNameless"},
+    { name = "ItsNameless" },
 ]
 description = "Prompting - the fancy way"
 readme = "README.md"
@@ -15,11 +15,11 @@ dependencies = [
     "prompt-toolkit>=3.0.37,<4.0",
 ]
 classifiers = [
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
 ]
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 
 [project.urls]
 Homepage = "https://github.com/TheItsProjects/ItsPrompt"
@@ -45,6 +45,12 @@ filterwarnings = [
     # ignore warning, see https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1696
     "ignore:There is no current event loop:DeprecationWarning",
 ]
+
+[tool.yapf]
+space_between_ending_comma_and_closing_bracket = false
+column_limit = 120
+each_dict_entry_on_separate_line = false
+dedent_closing_brackets = true
 
 [tool.mypy]
 packages = "ItsPrompt"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ mypy==1.2.0
 pytest-cov==4.0.0
 pandas-stubs==2.0.1.230501
 pandas>=1.5.3
+toml==0.10.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ yapf==0.32.0
 mypy==1.2.0
 pytest-cov==4.0.0
 pandas-stubs==2.0.1.230501
+pandas>=1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 prompt-toolkit>=3.0.37,<4.0
-pandas>=1.5.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,24 @@
+import os
+from typing import NamedTuple
+
 import pytest
 from prompt_toolkit.application import create_app_session
 from prompt_toolkit.input import create_pipe_input, ansi_escape_sequences, PipeInput
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.output import DummyOutput
 
-import os
-
-from typing import NamedTuple
-
 
 def key_converter(*keys: Keys | str) -> str:
-    '''
+    """
     Convert a key sequence to a sequence of stringified keys
 
     The keys may either be a `prompt_toolkit.keys.Keys` or a string, which will be interpreted as text to type.
-    
+
     The returned string is usable with `PipeInput.send_text()`.
 
     :return: all given keys combined to a single string
     :rtype: str
-    '''
+    """
     out = ""
 
     for key in keys:
@@ -33,11 +32,11 @@ def key_converter(*keys: Keys | str) -> str:
 
 @pytest.fixture(autouse=True, scope="function")
 def mock_input():
-    '''
+    """
     Fixture for creating a dummy prompt session
-    
+
     Terminal inputs can be created by using pipe_input.
-    '''
+    """
     with create_pipe_input() as pipe_input:
         with create_app_session(input=pipe_input, output=DummyOutput()):
             yield pipe_input
@@ -45,11 +44,12 @@ def mock_input():
 
 @pytest.fixture(autouse=True, scope="function")
 def send_keys(mock_input: PipeInput):
-    '''
+    """
     Fixture for easily sending keys to the terminal session
-    
-    The returned callable can be called to convert a list of Keys or strings to one string, which will then be sent to the terminal session via PipeInput.
-    '''
+
+    The returned callable can be called to convert a list of Keys or strings to one string, which will then be sent
+    to the terminal session via PipeInput.
+    """
     yield lambda *x: mock_input.send_text(key_converter(*x))
 
 
@@ -62,11 +62,11 @@ class FakeTerminalSize(NamedTuple):
 def mock_terminal_size(monkeypatch: pytest.MonkeyPatch):
 
     def get_fake_terminal_size(x=None):
-        '''
+        """
         Fixture for mocking the output of the `os.get_terminal_size()` method
-        
+
         This fixture is needed in order for `TablePrompt()` to work.
-        '''
+        """
         return FakeTerminalSize(180, 60)
 
     monkeypatch.setattr(os, "get_terminal_size", get_fake_terminal_size)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from typing import NamedTuple
 
 import pytest
 from prompt_toolkit.application import create_app_session
-from prompt_toolkit.input import create_pipe_input, ansi_escape_sequences, PipeInput
+from prompt_toolkit.input import PipeInput, ansi_escape_sequences, create_pipe_input
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.output import DummyOutput
 

--- a/tests/data/test_checkbox.py
+++ b/tests/data/test_checkbox.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ItsPrompt.data.checkbox import process_data, CheckboxOption
+from ItsPrompt.data.checkbox import CheckboxOption, process_data
 
 
 def test_process_data_standard_options():

--- a/tests/data/test_expand.py
+++ b/tests/data/test_expand.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ItsPrompt.data.expand import process_data, ExpandOption
+from ItsPrompt.data.expand import ExpandOption, process_data
 
 
 def test_process_data_standard_options():
@@ -45,28 +45,28 @@ def test_process_data_raises_unique_keys():
 
 
 def test_process_data_raises_key_too_long():
-    options = (("tt", "too long", "tt"), )
+    options = (("tt", "too long", "tt"),)
 
     with pytest.raises(ValueError):
         ans = process_data(options)
 
 
 def test_process_data_raises_key_not_ascii():
-    options = (("❓", "not ascii", "na"), )
+    options = (("❓", "not ascii", "na"),)
 
     with pytest.raises(ValueError):
         ans = process_data(options)
 
 
 def test_process_data_raises_h_given():
-    options = (("h", "h given", "h"), )
+    options = (("h", "h given", "h"),)
 
     with pytest.raises(ValueError):
         ans = process_data(options)
 
 
 def test_process_data_raises_type_error():
-    options = (["i", "invalid"], )
+    options = (["i", "invalid"],)
 
     with pytest.raises(TypeError):
         ans = process_data(options)  # type: ignore # mypy: ignore

--- a/tests/data/test_expand.py
+++ b/tests/data/test_expand.py
@@ -64,8 +64,6 @@ def test_process_data_raises_h_given():
     with pytest.raises(ValueError):
         ans = process_data(options)
 
-        print(ans)
-
 
 def test_process_data_raises_type_error():
     options = (["i", "invalid"], )

--- a/tests/data/test_select.py
+++ b/tests/data/test_select.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ItsPrompt.data.select import process_data, SelectOption
+from ItsPrompt.data.select import SelectOption, process_data
 
 
 def test_process_data_standard_options():

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -233,8 +233,7 @@ def test_checkbox(send_keys, keys: list[Keys | str], i: list[int]):
         [(" ", Keys.Up, " ", Keys.Enter), (2,)],
     ],
 )
-def test_checkbox_with_default(send_keys, keys: list[Keys | str],
-                               i: list[int]):
+def test_checkbox_with_default(send_keys, keys: list[Keys | str], i: list[int]):
     options = ("first", "second", "third")
 
     send_keys(*keys)
@@ -404,8 +403,7 @@ def test_input_raises_keyboard_interrupt(send_keys):
         ],
     ],
 )
-def test_table_dataframe(send_keys, mock_terminal_size, keys: list[Keys | str],
-                         a: DataFrame):
+def test_table_dataframe(send_keys, mock_terminal_size, keys: list[Keys | str], a: DataFrame):
     data = DataFrame(["first", "second", "third"])
 
     send_keys(*keys)
@@ -436,8 +434,7 @@ def test_table_dataframe(send_keys, mock_terminal_size, keys: list[Keys | str],
         ],
     ],
 )
-def test_table_dictionary(send_keys, mock_terminal_size, keys: list[Keys | str],
-                          a: dict[str, list[str]]):
+def test_table_dictionary(send_keys, mock_terminal_size, keys: list[Keys | str], a: dict[str, list[str]]):
     data = {"0": ["first", "second", "third"]}
 
     send_keys(*keys)
@@ -459,7 +456,7 @@ def test_table_raises_keyboard_interrupt(send_keys):
 def test_table_dictionary_raises_lists_not_same_lengths(send_keys):
     send_keys(Keys.ControlC)
 
-    data = {"0": ["first", "second", "third"], "1": ["other first", ]}
+    data = {"0": ["first", "second", "third"], "1": ["other first"]}
 
     with pytest.raises(ValueError):
         ans = Prompt.table("", data)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,19 +1,17 @@
-from ItsPrompt.prompt import Prompt
-
-from prompt_toolkit.keys import Keys
-from prompt_toolkit.completion import FuzzyWordCompleter
-
+import pytest
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
+from prompt_toolkit.completion import FuzzyWordCompleter
+from prompt_toolkit.keys import Keys
 
-import pytest
+from ItsPrompt.prompt import Prompt
 
 
 # --- Select ---
 @pytest.mark.parametrize(
     "keys,i",
     [
-        [(Keys.Enter, ), 0],
+        [(Keys.Enter,), 0],
         [(Keys.Down, Keys.Enter), 1],
         [(Keys.Down, Keys.Down, Keys.Enter), 2],
         [(Keys.Up, Keys.Enter), 2],
@@ -32,7 +30,7 @@ def test_select(send_keys, keys: list[Keys | str], i: int):
 @pytest.mark.parametrize(
     "keys,i",
     [
-        [(Keys.Enter, ), 1],
+        [(Keys.Enter,), 1],
         [(Keys.Down, Keys.Enter), 2],
         [(Keys.Down, Keys.Down, Keys.Enter), 0],
         [(Keys.Up, Keys.Enter), 0],
@@ -67,7 +65,7 @@ def test_select_raises_keyboard_interrupt(send_keys):
 @pytest.mark.parametrize(
     "keys,i",
     [
-        [(Keys.Enter, ), 0],
+        [(Keys.Enter,), 0],
         [("1", Keys.Enter), 0],
         [("2", Keys.Enter), 1],
         [(Keys.Up, Keys.Down, "abc", "99", Keys.Enter), 0],
@@ -86,7 +84,7 @@ def test_raw_select(send_keys, keys: list[Keys | str], i: int):
 @pytest.mark.parametrize(
     "keys,i",
     [
-        [(Keys.Enter, ), 1],
+        [(Keys.Enter,), 1],
         [("1", Keys.Enter), 0],
         [("2", Keys.Enter), 1],
     ],
@@ -104,7 +102,7 @@ def test_raw_select_with_default(send_keys, keys: list[Keys | str], i: int):
 @pytest.mark.parametrize(
     "keys,i",
     [
-        [(Keys.Enter, ), 0],
+        [(Keys.Enter,), 0],
         [(Keys.Down, Keys.Enter), 1],
         [(Keys.Up, Keys.Enter), 2],
     ],
@@ -210,9 +208,9 @@ def test_expand_raises_keyboard_interrupt(send_keys):
 @pytest.mark.parametrize(
     "keys,i",
     [
-        [(Keys.Enter, ), ()],
-        [(" ", Keys.Enter), (0, )],
-        [(Keys.Down, " ", Keys.Enter), (1, )],
+        [(Keys.Enter,), ()],
+        [(" ", Keys.Enter), (0,)],
+        [(Keys.Down, " ", Keys.Enter), (1,)],
         [(" ", Keys.Up, " ", Keys.Enter), (0, 2)],
     ],
 )
@@ -229,10 +227,10 @@ def test_checkbox(send_keys, keys: list[Keys | str], i: list[int]):
 @pytest.mark.parametrize(
     "keys,i",
     [
-        [(Keys.Enter, ), (0, )],
+        [(Keys.Enter,), (0,)],
         [(" ", Keys.Enter), ()],
         [(Keys.Down, " ", Keys.Enter), (0, 1)],
-        [(" ", Keys.Up, " ", Keys.Enter), (2, )],
+        [(" ", Keys.Up, " ", Keys.Enter), (2,)],
     ],
 )
 def test_checkbox_with_default(send_keys, keys: list[Keys | str],
@@ -241,7 +239,7 @@ def test_checkbox_with_default(send_keys, keys: list[Keys | str],
 
     send_keys(*keys)
 
-    ans = Prompt.checkbox("", options, default_checked=("first", ))
+    ans = Prompt.checkbox("", options, default_checked=("first",))
 
     assert ans == [options[n] for n in i]
 
@@ -250,7 +248,7 @@ def test_checkbox_raises_invalid_default():
     options = ("first", "second", "third")
 
     with pytest.raises(ValueError):
-        ans = Prompt.checkbox("", options, default_checked=("invalid", ))
+        ans = Prompt.checkbox("", options, default_checked=("invalid",))
 
 
 def test_checkbox_raises_keyboard_interrupt(send_keys):
@@ -312,7 +310,7 @@ def test_confirm_raises_keyboard_interrupt(send_keys):
 @pytest.mark.parametrize(
     "keys,a",
     [
-        [(Keys.Enter, ), ""],
+        [(Keys.Enter,), ""],
         [("test", Keys.Enter), "test"],
     ],
 )
@@ -327,7 +325,7 @@ def test_input(send_keys, keys: list[Keys | str], a: str):
 @pytest.mark.parametrize(
     "keys,a",
     [
-        [(Keys.Enter, ), "default"],
+        [(Keys.Enter,), "default"],
         [("test", Keys.Enter), "test"],
     ],
 )
@@ -345,7 +343,7 @@ KeysAltEnter = Keys.Escape, Keys.Enter  # Vt100 terminals convert "alt+key" to "
 @pytest.mark.parametrize(
     "keys,a",
     [
-        [(*KeysAltEnter, ), ""],
+        [(*KeysAltEnter,), ""],
         [("test", Keys.Enter, *KeysAltEnter), "test\n"],
     ],
 )
@@ -389,7 +387,7 @@ def test_input_raises_keyboard_interrupt(send_keys):
     "keys,a",
     [
         [
-            (Keys.Enter, ),
+            (Keys.Enter,),
             DataFrame({"0": ["first", "second", "third"]}),
         ],
         [
@@ -406,8 +404,8 @@ def test_input_raises_keyboard_interrupt(send_keys):
         ],
     ],
 )
-def test_table(send_keys, mock_terminal_size, keys: list[Keys | str],
-               a: DataFrame):
+def test_table_dataframe(send_keys, mock_terminal_size, keys: list[Keys | str],
+                         a: DataFrame):
     data = DataFrame(["first", "second", "third"])
 
     send_keys(*keys)
@@ -417,10 +415,51 @@ def test_table(send_keys, mock_terminal_size, keys: list[Keys | str],
     assert_frame_equal(ans, a)
 
 
-def test_able_raises_keyboard_interrupt(send_keys):
+@pytest.mark.parametrize(
+    "keys,a",
+    [
+        [
+            (Keys.Enter,),
+            {"0": ["first", "second", "third"]},
+        ],
+        [
+            (Keys.Down, "new", Keys.Enter),
+            {"0": ["first", "secondnew", "third"]},
+        ],
+        [
+            (Keys.Left, Keys.Right, Keys.Up, Keys.Down, Keys.Enter),
+            {"0": ["first", "second", "third"]},
+        ],
+        [
+            (Keys.Backspace, Keys.Enter),
+            {"0": ["firs", "second", "third"]},
+        ],
+    ],
+)
+def test_table_dictionary(send_keys, mock_terminal_size, keys: list[Keys | str],
+                          a: dict[str, list[str]]):
+    data = {"0": ["first", "second", "third"]}
+
+    send_keys(*keys)
+
+    ans = Prompt.table("", data)
+
+    assert ans == a
+
+
+def test_table_raises_keyboard_interrupt(send_keys):
     send_keys(Keys.ControlC)
 
     data = DataFrame(["first", "second", "third"])
 
     with pytest.raises(KeyboardInterrupt):
+        ans = Prompt.table("", data)
+
+
+def test_table_dictionary_raises_lists_not_same_lengths(send_keys):
+    send_keys(Keys.ControlC)
+
+    data = {"0": ["first", "second", "third"], "1": ["other first", ]}
+
+    with pytest.raises(ValueError):
         ans = Prompt.table("", data)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -390,19 +390,19 @@ def test_input_raises_keyboard_interrupt(send_keys):
     [
         [
             (Keys.Enter, ),
-            DataFrame(["first", "second", "third"], dtype="string"),
+            DataFrame({"0": ["first", "second", "third"]}),
         ],
         [
             (Keys.Down, "new", Keys.Enter),
-            DataFrame(["first", "secondnew", "third"], dtype="string"),
+            DataFrame({"0": ["first", "secondnew", "third"]}),
         ],
         [
             (Keys.Left, Keys.Right, Keys.Up, Keys.Down, Keys.Enter),
-            DataFrame(["first", "second", "third"], dtype="string"),
+            DataFrame({"0": ["first", "second", "third"]}),
         ],
         [
             (Keys.Backspace, Keys.Enter),
-            DataFrame(["firs", "second", "third"], dtype="string"),
+            DataFrame({"0": ["firs", "second", "third"]}),
         ],
     ],
 )


### PR DESCRIPTION
Modified `TablePrompt` to work with dictionaries, without having the need to install `pandas`.

Pandas is a big python package, and ItsPrompt should be as lightweight as possible. Now, by default, `ItsPrompt` will not be shipped with pandas, instead `TablePrompt` will use a dictionary in the style of:

```py
{"column 1: ["item 1", "item 2"]}
```

and return this as well.

To use `pandas.DataFrame`, you need to install the support with

```
pip install ItsPrompt[df]
```

or simply installing `pandas` separately.