### PR TITLE
Tableprompt lists

### DIFF
--- a/ItsPrompt/data/table.py
+++ b/ItsPrompt/data/table.py
@@ -1,8 +1,10 @@
 import os
 from typing import TYPE_CHECKING, Union
 
+from .type import TablePromptDict, TablePromptList
 from ..objects.table.table_base import TableDataBase
 from ..objects.table.table_dict import TableDataFromDict
+from ..objects.table.table_list import TableDataFromList
 
 # only import pandas and TableData if pandas is installed
 try:
@@ -19,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 class Table:
 
-    def __init__(self, data: Union["DataFrame", dict[str, list[str]]]) -> None:
+    def __init__(self, data: Union["DataFrame", TablePromptDict, TablePromptList]) -> None:
         """
         Creates a table object for storing the drawable table instance
 
@@ -31,6 +33,8 @@ class Table:
         self.data: TableDataBase
         if type(data) is dict:
             self.data = TableDataFromDict(data)
+        elif type(data) is list:
+            self.data = TableDataFromList(data)
         elif type(data) is DataFrame:
             self.data = TableDataFromDF(data)
 

--- a/ItsPrompt/data/type.py
+++ b/ItsPrompt/data/type.py
@@ -1,1 +1,4 @@
 CompletionDict = dict[str, "CompletionDict | None"]
+
+TablePromptDict = dict[str, list[str]]
+TablePromptList = list[list[str]]

--- a/ItsPrompt/objects/table/table_dict.py
+++ b/ItsPrompt/objects/table/table_dict.py
@@ -1,11 +1,12 @@
 from typing import Generator
 
 from .table_base import TableDataBase
+from ...data.type import TablePromptDict
 
 
 class TableDataFromDict(TableDataBase):
 
-    def __init__(self, data: dict[str, list[str]]) -> None:
+    def __init__(self, data: TablePromptDict) -> None:
         # make sure every list has same length
         lengths = set([len(t) for t in data.values()])
         if len(lengths) != 1:
@@ -52,5 +53,5 @@ class TableDataFromDict(TableDataBase):
     def get_column_location(self, val: str) -> int:
         return self.columns.index(val)
 
-    def get_data(self) -> dict[str, list[str]]:
+    def get_data(self) -> TablePromptDict:
         return self.data

--- a/ItsPrompt/objects/table/table_list.py
+++ b/ItsPrompt/objects/table/table_list.py
@@ -1,0 +1,17 @@
+from .table_dict import TableDataFromDict
+from ...data.type import TablePromptDict, TablePromptList
+
+
+class TableDataFromList(TableDataFromDict):
+
+    def __init__(self, data: TablePromptList):
+        # convert list to dict
+        dict_data: TablePromptDict = {f"{col}": rows for col, rows in enumerate(data)}
+
+        super().__init__(dict_data)
+
+    def get_data(self) -> TablePromptList:  # type: ignore
+        # convert dict to list
+        list_data: TablePromptList = list(self.data.values())
+
+        return list_data

--- a/ItsPrompt/prompt.py
+++ b/ItsPrompt/prompt.py
@@ -29,7 +29,7 @@ from prompt_toolkit.layout.menus import (
 )
 
 from .data.style import PromptStyle, convert_style, default_style
-from .data.type import CompletionDict
+from .data.type import CompletionDict, TablePromptDict, TablePromptList
 from .keyboard_handler import generate_key_bindings
 from .prompts.checkbox import CheckboxPrompt
 from .prompts.confirm import ConfirmPrompt
@@ -473,9 +473,9 @@ class Prompt:
     def table(
         cls,
         question: str,
-        data: Union["DataFrame", dict[str, list[str]]],
+        data: Union["DataFrame", TablePromptDict, TablePromptList],
         style: PromptStyle | None = None,
-    ) -> Union["DataFrame", dict[str, list[str]]]:
+    ) -> Union["DataFrame", TablePromptDict, TablePromptList]:
         """
         Ask the user for filling out the displayed table.
 
@@ -483,12 +483,12 @@ class Prompt:
         has the ability to use the up, down and enter keys to navigate between the options and change the text in
         each cell.
 
-        The `data` is either a pandas DataFrame or a dictionary.
+        The `data` is either a pandas DataFrame, a list or a dictionary (more in the README.md).
 
         :param question: The question to display
         :type question: str
         :param data: The data to display
-        :type data: DataFrame | dict[str, list[str]]
+        :type data: DataFrame | TablePromptDict | TablePromptList
         :param style: A separate style to style the prompt (empty or None for default style), defaults to None
         :type style: PromptStyle | None, optional
         :raises KeyboardInterrupt: When the user presses ctrl-c, `KeyboardInterrupt` will be raised

--- a/ItsPrompt/prompts/table.py
+++ b/ItsPrompt/prompts/table.py
@@ -6,6 +6,7 @@ from prompt_toolkit.data_structures import Point
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 from ..data.table import Table
+from ..data.type import TablePromptDict
 
 if TYPE_CHECKING:  # pragma: no cover
     from pandas import DataFrame
@@ -48,10 +49,10 @@ class TablePrompt(Application):
 
         self.prompt_content.text = HTML(content)
 
-    def prompt(self) -> Union["DataFrame", dict[str, list[str]], None]:
+    def prompt(self) -> Union["DataFrame", TablePromptDict, None]:
         """start the application, returns the return value"""
         self.update()
-        out: Union["DataFrame", dict[str, list[str]], None] = self.run()
+        out: Union["DataFrame", TablePromptDict, None] = self.run()
 
         return out
 

--- a/ItsPrompt/prompts/table.py
+++ b/ItsPrompt/prompts/table.py
@@ -6,7 +6,7 @@ from prompt_toolkit.data_structures import Point
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 from ..data.table import Table
-from ..data.type import TablePromptDict
+from ..data.type import TablePromptDict, TablePromptList
 
 if TYPE_CHECKING:  # pragma: no cover
     from pandas import DataFrame
@@ -17,7 +17,7 @@ class TablePrompt(Application):
     def __init__(
         self,
         question: str,
-        data: Union["DataFrame", dict[str, list[str]]],
+        data: Union["DataFrame", TablePromptDict, TablePromptList],
         *args,
         **kwargs,
     ):

--- a/README.md
+++ b/README.md
@@ -228,13 +228,21 @@ Prompt.input(
 ![](https://raw.githubusercontent.com/TheItsProjects/ItsPrompt/main/media/table.png)
 
 ```py
+# using a dictionary
 Prompt.table(
     question="something",
     data={"0": ["something"]},
     style=my_style,
 )
 
-# or, after having installed pandas
+# using a list
+Prompt.table(
+    question="something",
+    data=[["something"]],
+    style=my_style,
+)
+
+# or, after having installed pandas, using a DataFrame
 
 Prompt.table(
     question='something',
@@ -266,10 +274,65 @@ If an option is given as a `tuple`, the first value will be the options name, th
 
 ### Data
 
-The `table` prompt takes a mandatory `data` argument, which needs to be a `pandas.DataFrame`.
+The `table` prompt takes a mandatory `data` argument, which needs to be either:
 
-This `DataFrame` is used as the content of the table. The user may change the fields of the table. The output of
-the `table` prompt is a `pandas.DataFrame` with the user given values.
+- a `TablePromptList`
+- a `TablePromptDict`
+- a `pandas.DataFrame` (NOTE: `pandas` needs to be installed!)
+
+The `data` is used as the content of the table. The user may change the fields of the table. The output of the `table`
+prompt is of the same type, as the input data is represented, with the user given values.
+
+***TablePromptList***
+
+This is a list of the type: `list[list[str]]`.
+
+Every sub-list is a column, every item is a cell.
+
+```py
+[["field 1", "field 2"], ["field 3", "field 4"]]
+```
+
+will be rendered:
+
+| 0       | 1       |
+|---------|---------|
+| field 1 | field 3 |
+| field 2 | field 4 |
+
+***TablePromptDict***
+
+This is a dictionary of the type: `dict[str, list[str]]`.
+
+Every key is a column name, every value is the column itself.
+
+```py
+{"column 1": ["field 1", "field 2"], "column 2": ["field 3", "field 4"]}
+```
+
+will be rendered:
+
+| column 1 | column 2 |
+|----------|----------|
+| field 1  | field 3  |
+| field 2  | field 4  |
+
+***DataFrame***
+
+To use `pandas.DataFrame`, you first need to install `pandas`.
+
+```py
+DataFrame(["field 1", "field 2"])
+```
+
+will be rendered:
+
+| 0       |
+|---------|
+| field 1 |
+| field 2 |
+
+***Additional information***
 
 Currently, the output will convert all input values to a `str`, so `int`, `bool`, ... will be converted to strings. This
 is a current limitation of the way the table is displayed, but may later be updated.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Prompt.select(
 )
 ```
 
+Read more about the options attribute at [Options](#options).
+
 *additional information on the function arguments can be found in the docstring*
 
 ### `raw_select`
@@ -153,6 +155,8 @@ Prompt.raw_select(
     style=my_style,
 )
 ```
+
+Read more about the options attribute at [Options](#options).
 
 *additional information on the function arguments can be found in the docstring*
 
@@ -170,6 +174,8 @@ Prompt.expand(
 )
 ```
 
+Read more about the options attribute at [Options](#options).
+
 *additional information on the function arguments can be found in the docstring*
 
 ### `checkbox`
@@ -186,6 +192,8 @@ Prompt.checkbox(
     style=my_style,
 )
 ```
+
+Read more about the options attribute at [Options](#options).
 
 *additional information on the function arguments can be found in the docstring*
 
@@ -221,6 +229,9 @@ Prompt.input(
 )
 ```
 
+Read more about the prompt validation and prompt completion attribute at [Prompt Validation](#prompt-validation)
+and [Prompt Commpletion](#prompt-completion).
+
 *additional information on the function arguments can be found in the docstring*
 
 ### `table`
@@ -251,6 +262,8 @@ Prompt.table(
 )
 ```
 
+Read more about the data attribute at [TablePrompt Data](#tableprompt-data).
+
 *additional information on the function arguments can be found in the docstring*
 
 ---
@@ -272,7 +285,7 @@ If an option is given as a `tuple`, the first value will be the options name, th
 
 ---
 
-### Data
+### TablePrompt Data
 
 The `table` prompt takes a mandatory `data` argument, which needs to be either:
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -4,6 +4,7 @@ from pandas.testing import assert_frame_equal
 from prompt_toolkit.completion import FuzzyWordCompleter
 from prompt_toolkit.keys import Keys
 
+from ItsPrompt.data.type import TablePromptDict, TablePromptList
 from ItsPrompt.prompt import Prompt
 
 
@@ -434,8 +435,39 @@ def test_table_dataframe(send_keys, mock_terminal_size, keys: list[Keys | str], 
         ],
     ],
 )
-def test_table_dictionary(send_keys, mock_terminal_size, keys: list[Keys | str], a: dict[str, list[str]]):
+def test_table_dictionary(send_keys, mock_terminal_size, keys: list[Keys | str], a: TablePromptDict):
     data = {"0": ["first", "second", "third"]}
+
+    send_keys(*keys)
+
+    ans = Prompt.table("", data)
+
+    assert ans == a
+
+
+@pytest.mark.parametrize(
+    "keys,a",
+    [
+        [
+            (Keys.Enter,),
+            [["first", "second", "third"]],
+        ],
+        [
+            (Keys.Down, "new", Keys.Enter),
+            [["first", "secondnew", "third"]],
+        ],
+        [
+            (Keys.Left, Keys.Right, Keys.Up, Keys.Down, Keys.Enter),
+            [["first", "second", "third"]],
+        ],
+        [
+            (Keys.Backspace, Keys.Enter),
+            [["firs", "second", "third"]],
+        ],
+    ],
+)
+def test_table_list(send_keys, mock_terminal_size, keys: list[Keys | str], a: TablePromptList):
+    data = [["first", "second", "third"]]
 
     send_keys(*keys)
 


### PR DESCRIPTION
This PR adds the option to use `TablePrompt` with a list of the type: `list[list[str]]`.

Additional Information can be found in the README.md.