### PR TITLE
[FIX] 41: Show selected option after key in expand prompt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ".*tests\/fixtures.*"
 repos:
   - repo: https://github.com/google/yapf
-    rev: v0.33.0
+    rev: v0.43.0
     hooks:
       - id: yapf
         args: [ --diff ]

--- a/ItsPrompt/data/expand.py
+++ b/ItsPrompt/data/expand.py
@@ -12,9 +12,27 @@ class ExpandOption(Option):
     name: str
     id: str
     is_disabled: bool
+    
+class ExpandOptionsWithSeparator(OptionsWithSeparator[ExpandOption | Separator]):
+    
+    def __init__(self, *args: ExpandOption | Separator):
+        super().__init__(*args)
+        
+    def get_option(self, key: str) -> ExpandOption | None:
+        """
+        Get the option with the given key.
 
+        :param key: The key of the option to get
+        :type key: str
+        :return: The option with the given key or None if not found
+        :rtype: ExpandOption | None
+        """
+        for option in self.with_separators:
+            if isinstance(option, ExpandOption) and option.key == key:
+                return option
+        return None
 
-def process_data(options: OptionsList) -> OptionsWithSeparator[ExpandOption | Separator]:
+def process_data(options: OptionsList) -> ExpandOptionsWithSeparator:
     """
     Processes the given `options` and returns the processed list
 
@@ -70,5 +88,5 @@ def process_data(options: OptionsList) -> OptionsWithSeparator[ExpandOption | Se
     processed_options.append(
         ExpandOption(key='h', name='Help Menu, list or hide all options', id='', is_disabled=False)
     )
-
-    return OptionsWithSeparator(*processed_options)
+    
+    return ExpandOptionsWithSeparator(*processed_options)

--- a/ItsPrompt/data/expand.py
+++ b/ItsPrompt/data/expand.py
@@ -12,12 +12,13 @@ class ExpandOption(Option):
     name: str
     id: str
     is_disabled: bool
-    
+
+
 class ExpandOptionsWithSeparator(OptionsWithSeparator[ExpandOption | Separator]):
-    
+
     def __init__(self, *args: ExpandOption | Separator):
         super().__init__(*args)
-        
+
     def get_option(self, key: str) -> ExpandOption | None:
         """
         Get the option with the given key.
@@ -31,6 +32,7 @@ class ExpandOptionsWithSeparator(OptionsWithSeparator[ExpandOption | Separator])
             if isinstance(option, ExpandOption) and option.key == key:
                 return option
         return None
+
 
 def process_data(options: OptionsList) -> ExpandOptionsWithSeparator:
     """
@@ -88,5 +90,5 @@ def process_data(options: OptionsList) -> ExpandOptionsWithSeparator:
     processed_options.append(
         ExpandOption(key='h', name='Help Menu, list or hide all options', id='', is_disabled=False)
     )
-    
+
     return ExpandOptionsWithSeparator(*processed_options)

--- a/ItsPrompt/objects/prompts/options_with_separator.py
+++ b/ItsPrompt/objects/prompts/options_with_separator.py
@@ -1,8 +1,9 @@
 from typing import Iterator, TypeVar, Generic
 
+from ItsPrompt.objects.prompts.option import Option
 from ItsPrompt.objects.prompts.separator import Separator
 
-OptionOrSeparator = TypeVar("OptionOrSeparator")
+OptionOrSeparator = TypeVar("OptionOrSeparator", bound=Option | Separator)
 
 
 class OptionsWithSeparator(Generic[OptionOrSeparator], list):

--- a/ItsPrompt/prompts/expand.py
+++ b/ItsPrompt/prompts/expand.py
@@ -94,7 +94,7 @@ class ExpandPrompt(Application):
                     content += f'\n{disabled[0]}<option>    {option.key}) {option.name}</option>{disabled[1]}'  # type: ignore
 
         # text
-        content += f'\n<text>    Answer: {self.selection} ({self.options.get_option(self.selection).name})</text>' # type: ignore
+        content += f'\n<text>    Answer: {self.selection} ({self.options.get_option(self.selection).name})</text>'  # type: ignore
 
         self.prompt_content.text = HTML(content)
 

--- a/ItsPrompt/prompts/expand.py
+++ b/ItsPrompt/prompts/expand.py
@@ -94,7 +94,7 @@ class ExpandPrompt(Application):
                     content += f'\n{disabled[0]}<option>    {option.key}) {option.name}</option>{disabled[1]}'  # type: ignore
 
         # text
-        content += f'\n<text>    Answer: {self.selection}</text>'
+        content += f'\n<text>    Answer: {self.selection} ({self.options.get_option(self.selection).name})</text>' # type: ignore
 
         self.prompt_content.text = HTML(content)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pre-commit==3.3.1
 pytest==7.3.1
-yapf==0.32.0
+yapf==0.43.0
 mypy==1.2.0
 pytest-cov==4.0.0
 pandas-stubs==2.0.1.230501


### PR DESCRIPTION
With this PR the expand prompt now shows the name of the currently selected option behind the key:

![grafik](https://github.com/user-attachments/assets/0de84d58-7b43-41c3-a5af-6dacdd6a32e4)
